### PR TITLE
Missing tcl file

### DIFF
--- a/common/tcl/add_src.tcl
+++ b/common/tcl/add_src.tcl
@@ -1,0 +1,23 @@
+############################################################################
+############################################################################
+##
+## Copyright 2018 International Business Machines
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+############################################################################
+############################################################################
+
+#Adding source files
+add_files -scan_for_includes $common_src/ >> $log_file
+add_files -scan_for_includes $fpga_src/ >> $log_file


### PR DESCRIPTION
This missing file prevents from reloading binaries through PCIe (in this case use JTAG long download process)

Signed-off-by: Alexandre Castellane alexandre.castellane@fr.ibm.com