### PR TITLE
AD9V3 and N250SP: Fix factory vs. user image load

### DIFF
--- a/AD9V3/src/capi_board_infrastructure.vhdl
+++ b/AD9V3/src/capi_board_infrastructure.vhdl
@@ -406,12 +406,10 @@ Signal spi_mosi_secondary_out: std_logic;
 Signal spi_miso_secondary_in: std_logic;
 Signal spi_cen_secondary_out: std_logic;
 
-Signal golden_user: std_logic;
 Signal dummy_q: std_logic_vector(0 to 63);
 Signal dummy_reduce: std_logic;
 
 attribute dont_touch : string;
-attribute dont_touch of golden_user : signal is "true";
 attribute dont_touch of dummy_q : signal is "true";
 
 begin
@@ -422,16 +420,6 @@ dff_dummy_q: capi_rise_vdff GENERIC MAP ( width => 64 ) PORT MAP (
          clk   => pcihip0_psl_clk
 );
 dummy_reduce <= or_reduce(dummy_q);
-
----------------------
--- User vs. Factory image select
----------------------
-
-dff_golden_user: capi_rise_dff_init1 PORT MAP (
-  dout => golden_user,
-  din => golden_user,
-  clk   => icap_clk
-);
 
 
 --===================
@@ -467,7 +455,7 @@ v:       capi_vsec
 
 
          pci_pi_nperst0  => pci_pi_nperst0,
-         cpld_usergolden  => golden_user,
+         cpld_usergolden  => cpld_usergolden,
          cpld_softreconfigreq  => cpld_softreconfigreq,
          cpld_user_bs_req  => cpld_user_bs_req,
          cpld_oe   => cpld_oe,

--- a/AD9V3/src/capi_vsec.vhdl
+++ b/AD9V3/src/capi_vsec.vhdl
@@ -95,6 +95,8 @@ ENTITY capi_vsec IS
 
 END capi_vsec;
 
+
+
 ARCHITECTURE capi_vsec OF capi_vsec IS
 
 Component capi_rise_dff
@@ -675,7 +677,7 @@ begin
          din => cpld_usergolden,
          clk   => psl_clk
     );
-	cfg_ext_read_data		<= cseb_rddata_in;
+    cfg_ext_read_data    <= cseb_rddata_in;
     cseb_wrresp_valid_in <=  not (f_program_data_valinternal  and  cseb_wrresp_req_l  and  cseb_wren_l  and  vsec_0x5C) ;
 
  -- -- End Section -- --
@@ -776,7 +778,9 @@ begin
     sreconfig_en <= vsec_0x10  and  cseb_be_l(0)  and  wren_pulse_in ;
 
     sreconfig_wdat2 <=  not vsec_wrdata(2) ;
-    sreconfig_wdat3 <=  not vsec_wrdata(3) ;
+    -- image_loaded: 0=factory 1=user.  If this is user image, invert bit 3
+    -- (aka bit 28 - image select) so that default is to reload same image
+    sreconfig_wdat3 <=  image_loaded xor vsec_wrdata(3) ;
     sreconfig_wrdat <= ( sreconfig_wdat2 & sreconfig_wdat3 );
 
     -- v2bit reconfig_cntl_d = vsec_wrdata.[2..3];
@@ -791,7 +795,7 @@ begin
     v10const <= "0000000000000000000000000000" ;  -- Base Image Revision --
 
     sreconfig_rdat2 <=  not reconfig_cntl_q(0) ;
-    sreconfig_rdat3 <=  not reconfig_cntl_q(1) ;
+    sreconfig_rdat3 <=  image_loaded xor reconfig_cntl_q(1) ;
     --concat(type=v32bit) (vsec10data, image_loaded, 0b0, reconfig_cntl_q, v10const);
     vsec10data <= ( image_loaded & '0' & sreconfig_rdat2 & sreconfig_rdat3 & v10const );
 

--- a/N250SP/src/capi_board_infrastructure.vhdl
+++ b/N250SP/src/capi_board_infrastructure.vhdl
@@ -396,12 +396,6 @@ signal prf_wr_dynamic_bw: std_logic_vector(0 to 31); -- NEW
 signal efes16:  std_logic_vector(0 to 15);
 signal efes64:  std_logic_vector(0 to 63);
 
-Signal gold_factory: std_logic;
-
-attribute mark_debug of i2cacc_rden : signal is "true";
-attribute mark_debug of i2cacc_wren : signal is "true";
-attribute mark_debug of i2cacc_data : signal is "true";
-attribute mark_debug of i2cacc_rddata : signal is "true";
 
 begin
 


### PR DESCRIPTION
I only fixed AD9V3 and N250SP since the versions for RCXVUP, FX609 and S241 are currently under rework by @acastellane and @flyingegret2018 