### PR TITLE
U200 and some fixes for 2018.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 SHELL=/bin/bash
 export ROOT_DIR ?= $(abspath .)
 
-export CARDS += AD9V3 N250SP RCXVUP FX609 S241
+export CARDS += AD9V3 N250SP RCXVUP FX609 S241 U200
 
 include $(ROOT_DIR)/capi_bsp_env.mk
 
@@ -32,6 +32,7 @@ help:
 	@echo "* RCXVUP         Creates capi_bsp ip for XpressVUP-LP9PT card";
 	@echo "* FX609          Creates capi_bsp ip for Flyslice-FX609QL card";
 	@echo "* S241           Creates capi_bsp ip for Semptian S241 card";
+	@echo "* U200           Creates capi_bsp ip for Xilinx U200 card";
 	@echo "* clean          Removes all files generated in make process";
 	@echo "* help           Prints this message";
 	@echo "* Example : make AD9V3";

--- a/U200/Makefile
+++ b/U200/Makefile
@@ -1,0 +1,27 @@
+#
+# Copyright 2018 International Business Machines
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+SHELL=/bin/bash
+
+export FPGA_CARD    = U200
+export FPGA_DISPLAY = "Xilinx-U200"
+
+#Note: Set FPGA_PART first, then change to BOARD_PART
+export FPGA_PART    = xcu200-fsgd2104-2-e
+export BOARD_PART   = xilinx.com:au200:part0:1.0
+export FPGA_SRC     = $(ROOT_DIR)/ultrascale_plus/src
+
+include ../capi_card.mk

--- a/U200/README.md
+++ b/U200/README.md
@@ -1,0 +1,2 @@
+# Xilinx U200
+PSL and board support for Flyslice card with Xilinx VU9P FPGA

--- a/U200/src/capi_board_infrastructure.vhdl
+++ b/U200/src/capi_board_infrastructure.vhdl
@@ -1,0 +1,629 @@
+-- *!***************************************************************************
+-- *! Copyright 2014-2018 International Business Machines
+-- *!
+-- *! Licensed under the Apache License, Version 2.0 (the "License");
+-- *! you may not use this file except in compliance with the License.
+-- *! You may obtain a copy of the License at
+-- *!
+-- *!     http://www.apache.org/licenses/LICENSE-2.0
+-- *!
+-- *! Unless required by applicable law or agreed to in writing, software
+-- *! distributed under the License is distributed on an "AS IS" BASIS,
+-- *! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- *! See the License for the specific language governing permissions and
+-- *! limitations under the License.
+-- *!
+-- *!***************************************************************************
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_misc.all;
+Library UNISIM;
+use UNISIM.vcomponents.all;
+
+-- CAPI board infrastructure
+ENTITY capi_board_infrastructure IS
+  PORT(
+         cfg_ext_read_received         : IN    STD_LOGIC;
+         cfg_ext_write_received        : IN    STD_LOGIC;
+         cfg_ext_register_number       : IN    STD_LOGIC_VECTOR(9 DOWNTO 0);
+         cfg_ext_function_number       : IN    STD_LOGIC_VECTOR(7 DOWNTO 0);
+         cfg_ext_write_data            : IN    STD_LOGIC_VECTOR(31 DOWNTO 0);
+         cfg_ext_write_byte_enable     : IN    STD_LOGIC_VECTOR(3 DOWNTO 0);
+         cfg_ext_read_data             : OUT   STD_LOGIC_VECTOR(31 DOWNTO 0);
+         cfg_ext_read_data_valid       : OUT   STD_LOGIC;
+
+--         spi_miso_secondary            : in    std_logic;
+--         spi_mosi_secondary            : out   std_logic;
+--         spi_cen_secondary             : out   std_logic;
+
+         pci_pi_nperst0                : in    std_logic;
+         pcihip0_psl_clk               : in    std_logic;
+         icap_clk                      : in    std_logic;
+         cpld_usergolden               : in    std_logic;  -- bool
+         crc_error                     : out   std_logic
+
+          );  -- data
+END capi_board_infrastructure;
+
+ARCHITECTURE capi_board_infrastructure OF capi_board_infrastructure IS
+
+Component capi_rise_dff
+  PORT (clk   : in std_logic;
+        dout  : out std_logic;
+        din   : in std_logic);
+End Component capi_rise_dff;
+
+Component capi_rise_dff_init1
+  PORT (clk   : in std_logic;
+        dout  : out std_logic;
+        din   : in std_logic);
+End Component capi_rise_dff_init1;
+
+Component capi_rise_vdff
+  GENERIC ( width : positive );
+  PORT (clk   : in std_logic;
+        dout  : out std_logic_vector(0 to width-1);
+        din   : in std_logic_vector(0 to width-1));
+End Component capi_rise_vdff;
+
+--Component capi_gpio1
+--  PORT(pin: inout std_logic;
+--         id                            : out   std_logic;
+--         od                            : in    std_logic;
+--oe:      in std_logic);
+--End Component capi_gpio1;
+--
+--
+--  Component capi_gpo1
+--    PORT(pin: out std_logic;
+--         od                            : in    std_logic;
+--oe:      in std_logic);
+--  End Component capi_gpo1;
+--
+--  Component capi_gpo26
+--    PORT(pin: out std_logic_vector(0 to 25);
+--         od                            : in    std_logic_vector(0 to 25);
+--oe:      in std_logic);
+--  End Component capi_gpo26;
+--
+--  Component capi_gpio12
+--    PORT(pin: inout std_logic_vector(0 to 11);
+--         id                            : out   std_logic_vector(0 to 11);
+--         od                            : in    std_logic_vector(0 to 11);
+--oe:      in std_logic);
+--  End Component capi_gpio12;
+
+Component capi_i2c
+  PORT(psl_clk: in std_logic;
+
+       -- --------------- --
+         i2c0_scl_out                  : out   std_logic;
+         i2c0_scl_in                   : in    std_logic;
+         i2c0_sda_out                  : out   std_logic;
+         i2c0_sda_in                   : in    std_logic;
+
+       -- -------------- --
+         mi2c_cmdval                   : in    std_logic;
+         mi2c_dataval                  : in    std_logic;
+         mi2c_addr                     : in    std_logic_vector(0 to 6);
+         mi2c_rd                       : in    std_logic;
+         mi2c_cmdin                    : in    std_logic_vector(0 to 7);
+         mi2c_datain                   : in    std_logic_vector(0 to 7);
+         mi2c_blk                      : in    std_logic;
+         mi2c_bytecnt                  : in    std_logic_vector(0 to 7);
+         mi2c_cntlrsel                 : in    std_logic_vector(0 to 2);
+         i2cm_wrdatack                 : out   std_logic;
+         i2cm_dataval                  : out   std_logic;
+         i2cm_error                    : out   std_logic;
+         i2cm_dataout                  : out   std_logic_vector(0 to 7);
+i2cm_ready:out std_logic);
+End Component capi_i2c;
+
+Component capi_xilstrte3
+    PORT(datain: out std_logic_vector(0 to 3);
+         dataout                       : in    std_logic_vector(0 to 3);
+         ce_in                         : in    std_logic;
+         datat                         : in    std_logic;
+         ce_t                          :    in std_logic);
+End Component capi_xilstrte3;
+
+Component capi_vsec
+  PORT(psl_clk: in std_logic;
+         cfg_ext_read_received         : IN    STD_LOGIC;
+         cfg_ext_write_received        : IN    STD_LOGIC;
+         cfg_ext_register_number       : IN    STD_LOGIC_VECTOR(9 DOWNTO 0);
+         cfg_ext_function_number       : IN    STD_LOGIC_VECTOR(7 DOWNTO 0);
+         cfg_ext_write_data            : IN    STD_LOGIC_VECTOR(31 DOWNTO 0);
+         cfg_ext_write_byte_enable     : IN    STD_LOGIC_VECTOR(3 DOWNTO 0);
+         cfg_ext_read_data             : OUT   STD_LOGIC_VECTOR(31 DOWNTO 0);
+         cfg_ext_read_data_valid       : OUT   STD_LOGIC;
+
+       -- ------------ --
+         hi2c_cmdval                   : out   std_logic;
+         hi2c_dataval                  : out   std_logic;
+         hi2c_addr                     : out   std_logic_vector(0 to 6);
+         hi2c_rd                       : out   std_logic;
+         hi2c_cmdin                    : out   std_logic_vector(0 to 7);
+         hi2c_datain                   : out   std_logic_vector(0 to 7);
+         hi2c_blk                      : out   std_logic;
+         hi2c_bytecnt                  : out   std_logic_vector(0 to 7);
+         hi2c_cntlrsel                 : out   std_logic_vector(0 to 2);
+         i2ch_wrdatack                 : in    std_logic;
+         i2ch_dataval                  : in    std_logic;
+         i2ch_error                    : in    std_logic;
+         i2ch_dataout                  : in    std_logic_vector(0 to 7);
+         i2ch_ready                    : in    std_logic;
+
+
+         pci_pi_nperst0                : in    std_logic;
+         cpld_usergolden               : in    std_logic;
+         cpld_softreconfigreq          : out   std_logic;
+         cpld_user_bs_req              : out   std_logic;
+         cpld_oe                       : out   std_logic;
+
+       -- --------------- --
+         f_program_req                 : out   std_logic                   ;                                        -- Level --
+         f_num_blocks                  : out   std_logic_vector(0 to 15)    ;                          -- 128KB Block Size --
+         f_start_blk                   : out   std_logic_vector(0 to 9);
+         f_program_data                : out   std_logic_vector(0 to 31);
+         f_program_data_val            : out   std_logic;
+         f_program_data_ack            : in    std_logic;
+         f_ready                       : in    std_logic;
+         f_done                        : in    std_logic;
+         f_stat_erase                  : in    std_logic;
+         f_stat_program                : in    std_logic;
+         f_stat_read                   : in    std_logic;
+         f_remainder                   : in    std_logic_vector(0 to 9);
+         f_states                      : in    std_logic_vector(0 to 31);
+         f_memstat                     : in    std_logic_vector(0 to 15);
+         f_memstat_past                : in    std_logic_vector(0 to 15);
+       -- -------------- --
+         f_read_req                    : out   std_logic;
+         f_num_words_m1                : out   std_logic_vector(0 to 15)    ;                        -- N-1 words --
+         f_read_start_addr             : out   std_logic_vector(0 to 31);
+         f_read_data                   : in    std_logic_vector(0 to 31);
+         f_read_data_val               : in    std_logic;
+         f_read_data_ack               : out   std_logic;
+
+         i2cacc_wren : out std_logic;
+         i2cacc_data : out std_logic_vector(0 to 63);
+         i2cacc_rden : out std_logic;
+         i2cacc_rddata  : in std_logic_vector(0 to 63);
+
+         prf_wr_overall_ticks_data     : in    std_logic_vector(0 to 127);
+         prf_wr_overall_samples_data   : in    std_logic_vector(0 to 63);
+         prf_rd_overall_ticks_data     : in    std_logic_vector(0 to 127);
+         prf_rd_overall_samples_data   : in    std_logic_vector(0 to 63);
+         prf_rd_max_lat_dynamic_avg    : in    std_logic_vector(0 to 31);
+         prf_rd_dynamic_bw             : in    std_logic_vector(0 to 31)   ;  -- NEW
+         prf_wr_dynamic_bw             : in    std_logic_vector(0 to 31)   ;  -- NEW
+         prf_rd_max_lat :in std_logic_vector(0 to 31)
+       );
+End Component capi_vsec;
+
+Component capi_xilmltbt
+  PORT(psl_clk: in std_logic;
+         icap_clk                      : in    std_logic;
+         icap_request                  : in    std_logic;
+         icap_release                  : out   std_logic;
+         icap_grant                    : out   std_logic;
+         icap_mltbt_csib               : out   std_logic;
+         icap_mltbt_rdwrb              : out   std_logic;
+         icap_mltbt_writedata          : out   std_logic_vector(0 to 31);
+         icap_mltbt_takeover           : out   std_logic;
+         cpld_softreconfigreq          : in    std_logic;
+         cpld_user_bs_req              : in std_logic);
+End Component capi_xilmltbt;
+
+ Component capi_svcrc
+   PORT(
+         icap_release                  : in    std_logic;
+         icap_grant                    : in    std_logic;
+         icap_request                  : out   std_logic;
+         icap_clk                      : in    std_logic;
+         icap_mltbt_csib               : in    std_logic;
+         icap_mltbt_rdwrb              : in    std_logic;
+         icap_mltbt_writedata          : in    std_logic_vector(0 to 31);
+         icap_mltbt_takeover           : in    std_logic;
+crc_error:out std_logic);
+ End Component capi_svcrc;
+
+Component capi_flash_spi_mt25qt
+  PORT(psl_clk: in std_logic;
+
+       spi_clk: out std_logic;
+       spi_cen: out std_logic;
+       spi_miso : in std_logic;
+       spi_mosi : out std_logic;
+
+       -- --------------- --
+
+       -- -------------- --
+       f_program_req: in std_logic;                                         -- Level --
+       f_num_blocks: in std_logic_vector(0 to 15);                           -- 128KB Block Size --
+       f_start_blk: in std_logic_vector(0 to 9);
+       f_program_data: in std_logic_vector(0 to 31);
+       f_program_data_val: in std_logic;
+       f_program_data_ack: out std_logic;
+       f_ready: out std_logic;
+       f_done: out std_logic;
+       f_stat_erase: out std_logic;
+       f_stat_program: out std_logic;
+       f_stat_read: out std_logic;
+       f_remainder: out std_logic_vector(0 to 9);
+
+       -- Read Interface --
+       f_read_req: in std_logic;
+       f_num_words_m1: in std_logic_vector(0 to 15);                         -- N-1 words --
+       f_read_start_addr: in std_logic_vector(0 to 31);
+       f_read_data: out std_logic_vector(0 to 31);
+       f_read_data_val: out std_logic;
+       f_read_data_ack: in std_logic);
+End Component capi_flash_spi_mt25qt;
+
+Component capi_i2cacc
+  PORT(psl_clk: in std_logic;
+         b_basei2c_scl                 : inout std_logic                     ;                                       -- clock
+         b_basei2c_sda                 : inout std_logic                     ;                                       -- data
+
+         i2cacc_wren : in std_logic;
+         i2cacc_data : in std_logic_vector(0 to 63);
+         i2cacc_rden : in std_logic;
+         i2cacc_rddata : out std_logic_vector(0 to 63));
+
+end component capi_i2cacc;
+
+attribute mark_debug : string;
+
+Signal cpld_oe: std_logic;  -- bool
+Signal cpld_softreconfigreq: std_logic;  -- bool
+Signal cpld_user_bs_req: std_logic;  -- bool
+
+
+Signal f_done: std_logic;  -- bool
+Signal f_num_blocks: std_logic_vector(0 to 15);  -- v16bit
+Signal f_num_words_m1: std_logic_vector(0 to 15);  -- v16bit
+Signal f_program_data: std_logic_vector(0 to 31);  -- v32bit
+Signal f_program_data_ack: std_logic;  -- bool
+Signal f_program_data_val: std_logic;  -- bool
+Signal f_program_req: std_logic;  -- bool
+Signal f_read_data: std_logic_vector(0 to 31);  -- v32bit
+Signal f_read_data_ack: std_logic;  -- bool
+Signal f_read_data_val: std_logic;  -- bool
+Signal f_read_req: std_logic;  -- bool
+Signal f_read_start_addr: std_logic_vector(0 to 31);  -- v32bit
+Signal f_ready: std_logic;  -- bool
+Signal f_remainder: std_logic_vector(0 to 9);  -- v10bit
+Signal f_start_blk: std_logic_vector(0 to 9);  -- v10bit
+Signal f_stat_erase: std_logic;  -- bool
+Signal f_stat_program: std_logic;  -- bool
+Signal f_stat_read: std_logic;  -- bool
+
+Signal flash_addr: std_logic_vector(0 to 25);  -- v26bit
+Signal flash_advn: std_logic;  -- bool
+Signal flash_cen: std_logic_vector(0 to 1);  -- v2bit
+Signal flash_clk: std_logic;  -- bool
+Signal flash_dat_oe: std_logic;  -- bool
+Signal flash_datain: std_logic_vector(0 to 15);  -- v16bit
+Signal flash_dataout: std_logic_vector(0 to 15);  -- v16bit
+Signal flash_intf_oe: std_logic;  -- bool
+Signal flash_oen: std_logic;  -- bool
+Signal flash_rstn: std_logic;  -- bool
+Signal flash_wen: std_logic;  -- bool
+Signal flash_wpn: std_logic;  -- bool
+
+Signal f_states: std_logic_vector(0 to 31);
+Signal f_memstat: std_logic_vector(0 to 15);
+Signal f_memstat_past: std_logic_vector(0 to 15);
+
+signal i2cacc_wren : std_logic;
+signal i2cacc_data: std_logic_vector(0 to 63);
+signal i2cacc_rden : std_logic;
+signal i2cacc_rddata: std_logic_vector(0 to 63);
+
+Signal hi2c1_addr: std_logic_vector(0 to 6);
+Signal hi2c1_blk: std_logic;
+Signal hi2c1_bytecnt: std_logic_vector(0 to 7);  -- v8bit
+Signal hi2c1_cmdin: std_logic_vector(0 to 7);  -- v8bit
+Signal hi2c1_cmdval: std_logic;  -- bool
+Signal hi2c1_cntlrsel: std_logic_vector(0 to 2);  -- v3bit
+Signal hi2c1_datain: std_logic_vector(0 to 7);  -- v8bit
+Signal hi2c1_dataval: std_logic;  -- bool
+Signal hi2c1_rd: std_logic;  -- bool
+Signal i2c1_scl_en: std_logic;  -- bool
+Signal i2c1_scl_in: std_logic;  -- bool
+Signal i2c1_scl_out: std_logic;  -- bool
+Signal i2c1_sda_en: std_logic;  -- bool
+Signal i2c1_sda_in: std_logic;  -- bool
+Signal i2c1_sda_out: std_logic;  -- bool
+Signal i2ch1_dataout: std_logic_vector(0 to 7);  -- v8bit
+Signal i2ch1_dataval: std_logic;  -- bool
+Signal i2ch1_error: std_logic;  -- bool
+Signal i2ch1_ready: std_logic;  -- bool
+Signal i2ch1_wrdatack: std_logic;  -- bool
+Signal i2cm1_dataout: std_logic_vector(0 to 7);  -- v8bit
+Signal i2cm1_dataval: std_logic;  -- bool
+Signal i2cm1_error: std_logic;  -- bool
+Signal i2cm1_ready: std_logic;  -- bool
+Signal i2cm1_wrdatack: std_logic;  -- bool
+
+Signal mi2c_addr: std_logic_vector(0 to 6);  -- v7bit
+Signal mi2c_blk: std_logic;  -- bool
+Signal mi2c_bytecnt: std_logic_vector(0 to 7);  -- v8bit
+Signal mi2c_cmdin: std_logic_vector(0 to 7);  -- v8bit
+Signal mi2c_cmdval: std_logic;  -- bool
+Signal mi2c_cntlrsel: std_logic_vector(0 to 2);  -- v3bit
+Signal mi2c_datain: std_logic_vector(0 to 7);  -- v8bit
+Signal mi2c_dataval: std_logic;  -- bool
+Signal mi2c_rd: std_logic;  -- bool
+Signal mi2c1_addr: std_logic_vector(0 to 6);  -- v7bit
+Signal mi2c1_blk: std_logic;  -- bool
+Signal mi2c1_bytecnt: std_logic_vector(0 to 7);  -- v8bit
+Signal mi2c1_cmdin: std_logic_vector(0 to 7);  -- v8bit
+Signal mi2c1_cmdval: std_logic;  -- bool
+Signal mi2c1_cntlrsel: std_logic_vector(0 to 2);  -- v3bit
+Signal mi2c1_datain: std_logic_vector(0 to 7);  -- v8bit
+Signal mi2c1_dataval: std_logic;  -- bool
+Signal mi2c1_rd: std_logic;  -- bool
+
+
+Signal icap_grant: std_logic;  -- bool
+Signal icap_mltbt_csib: std_logic;  -- bool
+Signal icap_mltbt_rdwrb: std_logic;  -- bool
+Signal icap_mltbt_takeover: std_logic;  -- bool
+Signal icap_mltbt_writedata: std_logic_vector(0 to 31);  -- v32bit
+Signal icap_release: std_logic;  -- bool
+Signal icap_request: std_logic;  -- bool
+
+-- -------------- -- PRF vectors
+signal prf_wr_overall_ticks_data: std_logic_vector(0 to 127);
+signal prf_rd_overall_ticks_data: std_logic_vector(0 to 127);
+signal prf_wr_overall_samples_data: std_logic_vector(0 to 63);
+signal prf_rd_overall_samples_data: std_logic_vector(0 to 63);
+signal prf_rd_max_lat_dynamic_avg: std_logic_vector(0 to 31);
+signal prf_rd_max_lat: std_logic_vector(0 to 31);
+signal prf_rd_dynamic_bw: std_logic_vector(0 to 31); -- NEW
+signal prf_wr_dynamic_bw: std_logic_vector(0 to 31); -- NEW
+signal efes16:  std_logic_vector(0 to 15);
+signal efes64:  std_logic_vector(0 to 63);
+
+Signal spi_in_startup: std_logic_vector(0 to 3);
+Signal spi_in_primary: std_logic_vector(0 to 3);
+Signal spi_mosi_startup: std_logic;
+Signal spi_clk_startup: std_logic;
+Signal spi_cen_startup: std_logic;
+Signal fspi_mosi: std_logic;
+Signal fspi_clk: std_logic;
+Signal fspi_cen: std_logic;
+Signal fspi_miso: std_logic;
+Signal spi_clk: std_logic;
+Signal spi_cen_primary: std_logic;
+Signal spi_mosi_primary: std_logic;
+Signal drive_primary: std_logic;
+Signal drive_secondary: std_logic;
+--Signal spi_mosi_secondary_out: std_logic;
+--Signal spi_miso_secondary_in: std_logic;
+--Signal spi_cen_secondary_out: std_logic;
+
+Signal dummy_q: std_logic_vector(0 to 63);
+Signal dummy_reduce: std_logic;
+
+attribute dont_touch : string;
+attribute dont_touch of dummy_q : signal is "true";
+
+begin
+
+dff_dummy_q: capi_rise_vdff GENERIC MAP ( width => 64 ) PORT MAP (
+         dout => dummy_q,
+         din => dummy_q,
+         clk   => pcihip0_psl_clk
+);
+dummy_reduce <= or_reduce(dummy_q);
+
+
+--===================
+      -- Flash pins
+--===================
+
+    -- vsec logic
+v:       capi_vsec
+      PORT MAP (
+          cfg_ext_read_received => cfg_ext_read_received,
+      cfg_ext_write_received => cfg_ext_write_received,
+      cfg_ext_register_number => cfg_ext_register_number,
+      cfg_ext_function_number => cfg_ext_function_number,
+      cfg_ext_write_data => cfg_ext_write_data,
+      cfg_ext_write_byte_enable => cfg_ext_write_byte_enable,
+      cfg_ext_read_data => cfg_ext_read_data,
+      cfg_ext_read_data_valid => cfg_ext_read_data_valid,
+
+         hi2c_cmdval => hi2c1_cmdval,
+         hi2c_dataval => hi2c1_dataval,
+         hi2c_addr => hi2c1_addr,
+         hi2c_rd => hi2c1_rd,
+         hi2c_cmdin => hi2c1_cmdin,
+         hi2c_datain => hi2c1_datain,
+         hi2c_blk => hi2c1_blk,
+         hi2c_bytecnt => hi2c1_bytecnt,
+         hi2c_cntlrsel => hi2c1_cntlrsel,
+         i2ch_wrdatack => i2ch1_wrdatack,
+         i2ch_dataval => i2ch1_dataval,
+         i2ch_error => i2ch1_error,
+         i2ch_dataout => i2ch1_dataout,
+         i2ch_ready => i2ch1_ready,
+
+
+         pci_pi_nperst0  => pci_pi_nperst0,
+         cpld_usergolden  => cpld_usergolden,
+         cpld_softreconfigreq  => cpld_softreconfigreq,
+         cpld_user_bs_req  => cpld_user_bs_req,
+         cpld_oe   => cpld_oe,
+
+         f_program_req   => f_program_req,
+         f_num_blocks   => f_num_blocks,
+         f_start_blk   => f_start_blk,
+         f_program_data  => f_program_data,
+         f_program_data_val => f_program_data_val,
+         f_program_data_ack => f_program_data_ack,
+         f_ready    => f_ready,
+         f_done    => f_done,
+         f_stat_erase   => f_stat_erase,
+         f_stat_program  => f_stat_program,
+         f_stat_read   => f_stat_read,
+         f_remainder   => f_remainder,
+         f_states => X"0000000" & "000" & dummy_reduce,
+         f_memstat => X"0000",
+         f_memstat_past => X"0000",
+         f_read_req   => f_read_req,
+         f_num_words_m1  => f_num_words_m1,
+         f_read_start_addr  => f_read_start_addr,
+         f_read_data   => f_read_data,
+         f_read_data_val  => f_read_data_val,
+         f_read_data_ack  => f_read_data_ack,
+
+         i2cacc_wren => i2cacc_wren,
+         i2cacc_data => i2cacc_data,
+         i2cacc_rden => i2cacc_rden,
+         i2cacc_rddata => i2cacc_rddata,
+
+         prf_wr_overall_ticks_data   => prf_wr_overall_ticks_data,
+         prf_rd_overall_ticks_data   => prf_rd_overall_ticks_data,
+         prf_wr_overall_samples_data => prf_wr_overall_samples_data,
+         prf_rd_overall_samples_data => prf_rd_overall_samples_data,
+         prf_rd_max_lat_dynamic_avg  => prf_rd_max_lat_dynamic_avg,
+         prf_rd_max_lat  => prf_rd_max_lat,
+         prf_rd_dynamic_bw  => prf_rd_dynamic_bw,  -- NEW
+         prf_wr_dynamic_bw  => prf_wr_dynamic_bw,  -- NEW
+         psl_clk   => pcihip0_psl_clk  -- 250MHz clock, not a psl_clk
+    );
+
+      --startupe3 primitive must drive flash data 3:0 and ce on xilinx ultrascale parts
+--Startup Primitive Access to deicated config pins
+STARTUPE3_inst : STARTUPE3
+generic map (
+PROG_USR => "FALSE", -- Activate program event security feature. Requires encrypted bitstreams.
+SIM_CCLK_FREQ => 0.0 -- Set the Configuration Clock Frequency(ns) for simulation
+)
+port map (
+--CFGCLK => CFGCLK, -- 1-bit output: Configuration main clock output
+--CFGMCLK => CFGMCLK, -- 1-bit output: Configuration internal oscillator clock output
+DI => spi_in_startup, -- 4-bit output: Allow receiving on the D input pin
+--EOS => EOS, -- 1-bit output: Active-High output signal indicating the End Of Startup
+--PREQ => PREQ, -- 1-bit output: PROGRAM request to fabric output
+DO => ("000" & spi_mosi_startup), -- 4-bit input: Allows control of the D pin output
+DTS=> "1110", -- 4-bit input: Allows tristate of the D pin
+FCSBO => spi_cen_startup, -- 1-bit input: Contols the FCS_B pin for flash access
+FCSBTS => '0', -- 1-bit input: Tristate the FCS_B pin
+GSR => '0', -- 1-bit input: Global Set/Reset input (GSR cannot be used for the port)
+GTS => '0', -- 1-bit input: Global 3-state input (GTS cannot be used for the port name)
+KEYCLEARB => '1', -- 1-bit input: Clear AES Decrypter Key input from Battery-Backed RAM (BBRAM)
+PACK => '0', -- 1-bit input: PROGRAM acknowledge input
+USRCCLKO => spi_clk_startup, -- 1-bit input: User CCLK input
+USRCCLKTS => '0', -- 1-bit input: User CCLK 3-state enable input
+USRDONEO => '0', -- 1-bit input: User DONE pin output control
+USRDONETS => '1' -- 1-bit input: User DONE 3-state enable output
+);
+spi_cen_startup <= spi_cen_primary;
+spi_clk_startup <= spi_clk;
+spi_mosi_startup <= spi_mosi_primary;
+spi_in_primary <= spi_in_startup;
+
+--spi_clk <= vsec_spi_clk when (vsec_spi_mux = '1') else fspi_clk;
+--spi_cen <= vsec_spi_cen when (vsec_spi_mux = '1') else fspi_cen;
+--spi_mosi <= vsec_spi_mosi when (vsec_spi_mux = '1') else fspi_mosi;
+
+--vsec_spi_in <= spi_in;
+
+
+-- For SPIx4, we don't use secondary port.
+-------Drive secondary spi pins
+-----    IBUF_spi_miso_secondary : IBUF
+-----     port map (
+-----     O     => spi_miso_secondary_in,
+-----     I     => spi_miso_secondary
+-----    );
+-----
+-----    OBUF_spi_mosi_secondary : OBUFT
+-----     port map (
+-----     T     => '0',
+-----     O     => spi_mosi_secondary,
+-----     I     => spi_mosi_secondary_out
+-----    );
+-----    OBUF_spi_cen_secondary : OBUFT
+-----     port map (
+-----     T     => '0',
+-----     O     => spi_cen_secondary,
+-----     I     => spi_cen_secondary_out
+-----    );
+----
+----    -- Flash logic
+    f: capi_flash_spi_mt25qt
+      PORT MAP (
+         spi_clk => fspi_clk,
+         spi_cen => fspi_cen,
+         spi_miso => fspi_miso,
+         spi_mosi => fspi_mosi,
+         f_program_req => f_program_req,
+         f_num_blocks => f_num_blocks,
+         f_start_blk => f_start_blk,
+         f_program_data => f_program_data,
+         f_program_data_val => f_program_data_val,
+         f_program_data_ack => f_program_data_ack,
+         f_ready => f_ready,
+         f_done => f_done,
+         f_stat_erase => f_stat_erase,
+         f_stat_program => f_stat_program,
+         f_stat_read => f_stat_read,
+         f_remainder => f_remainder,
+         f_read_req => f_read_req,
+         f_num_words_m1 => f_num_words_m1,
+         f_read_start_addr => f_read_start_addr,
+         f_read_data => f_read_data,
+         f_read_data_val => f_read_data_val,
+         f_read_data_ack => f_read_data_ack,
+         psl_clk => pcihip0_psl_clk -- 250MHz clock, not a psl_clk
+    );
+
+-- Only Drive primary SPI. This is SPIx4
+-- 128MiB in total and split into 2 areas
+drive_primary <= '1';
+drive_secondary <= '0';
+spi_clk <= fspi_clk;
+spi_cen_primary <= fspi_cen when (drive_primary = '1') else '1';
+spi_mosi_primary <= fspi_mosi when (drive_primary = '1') else '1';
+--spi_cen_secondary_out <= fspi_cen when (drive_secondary = '1') else '1';
+--spi_mosi_secondary_out <= fspi_mosi when (drive_secondary = '1') else '1';
+--fspi_miso <= spi_miso_secondary_in when (drive_secondary = '1') else spi_in_primary(2);
+fspi_miso <= spi_in_primary(2);
+
+axihwicap:capi_xilmltbt
+      PORT MAP (
+         psl_clk => pcihip0_psl_clk,
+         icap_clk => icap_clk,
+         icap_request => icap_request,
+         icap_release => icap_release,
+         icap_grant => icap_grant,
+         icap_mltbt_csib => icap_mltbt_csib,
+         icap_mltbt_rdwrb => icap_mltbt_rdwrb,
+         icap_mltbt_writedata => icap_mltbt_writedata,
+         icap_mltbt_takeover => icap_mltbt_takeover,
+         cpld_softreconfigreq => cpld_softreconfigreq,
+         cpld_user_bs_req => cpld_user_bs_req
+    );
+
+crc:     capi_svcrc
+        PORT MAP (
+           icap_clk => icap_clk,
+           icap_release => icap_release,
+           icap_grant => icap_grant,
+           icap_request => icap_request,
+           icap_mltbt_csib => icap_mltbt_csib,
+           icap_mltbt_rdwrb => icap_mltbt_rdwrb,
+           icap_mltbt_writedata => icap_mltbt_writedata,
+           icap_mltbt_takeover => icap_mltbt_takeover,
+           crc_error => crc_error
+      );
+
+
+END capi_board_infrastructure;

--- a/U200/src/capi_bsp.vhdl
+++ b/U200/src/capi_bsp.vhdl
@@ -1,0 +1,1270 @@
+-- *!***************************************************************************
+-- *! Copyright 2014-2018 International Business Machines
+-- *!
+-- *! Licensed under the Apache License, Version 2.0 (the "License");
+-- *! you may not use this file except in compliance with the License.
+-- *! You may obtain a copy of the License at
+-- *!
+-- *!     http://www.apache.org/licenses/LICENSE-2.0
+-- *!
+-- *! Unless required by applicable law or agreed to in writing, software
+-- *! distributed under the License is distributed on an "AS IS" BASIS,
+-- *! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- *! See the License for the specific language governing permissions and
+-- *! limitations under the License.
+-- *!
+-- *!***************************************************************************
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+-- CAPI board support
+ENTITY capi_bsp IS
+  PORT(
+    --spi_miso_secondary    : in    std_logic;
+    --spi_mosi_secondary    : out   std_logic;
+    --spi_cen_secondary     : out   std_logic;
+
+-- pci interface
+    pcie_rst_n            : in    std_logic                     ;                                       -- Active low reset from the PCIe reset pin of the device
+    pcie_clkp      	  : in    std_logic                     ;                                       -- 100MHz Refclk
+    pcie_clkn             : in    std_logic                     ;                                       -- 100MHz Refclk
+
+-- Xilinx requires both pins of differential transceivers
+    pcie_txp              : out std_logic_vector(15 downto 0)   ;
+    pcie_txn              : out std_logic_vector(15 downto 0)   ;
+    pcie_rxp              : in  std_logic_vector(15 downto 0)   ;
+    pcie_rxn              : in  std_logic_vector(15 downto 0)   ;
+
+-- AFU interface (psl_accel)
+    -- Command interface
+    a0h_cvalid            : in    std_logic                  ; -- Command valid
+    a0h_ctag              : in    std_logic_vector(0 to 7)   ; -- Command tag
+    a0h_ctagpar           : in    std_logic                  ; -- Command tag parity
+    a0h_com               : in    std_logic_vector(0 to 12)  ; -- Command code
+    a0h_compar            : in    std_logic                  ; -- Command code parity
+    a0h_cabt              : in    std_logic_vector(0 to 2)   ; -- Command ABT
+    a0h_cea               : in    std_logic_vector(0 to 63)  ; -- Command address
+    a0h_ceapar            : in    std_logic                  ; -- Command address parity
+    a0h_cch               : in    std_logic_vector(0 to 15)  ; -- Command context handle
+    a0h_csize             : in    std_logic_vector(0 to 11)  ; -- Command size
+    a0h_cpagesize         : in    std_logic_vector(0 to 3)   ; -- ** New tie to 0000
+    ha0_croom             : out   std_logic_vector(0 to 7)   ; -- Command room
+    -- Buffer interface
+    ha0_brvalid           : out   std_logic                  ; -- Buffer Read valid
+    ha0_brtag             : out   std_logic_vector(0 to 7)   ; -- Buffer Read tag
+    ha0_brtagpar          : out   std_logic                  ; -- Buffer Read tag parity
+    ha0_brad              : out   std_logic_vector(0 to 5)   ; -- Buffer Read address
+    a0h_brlat             : in    std_logic_vector(0 to 3)   ; -- Buffer Read latency
+    a0h_brdata            : in    std_logic_vector(0 to 1023); -- Buffer Read data
+    a0h_brpar             : in    std_logic_vector(0 to 15)  ; -- Buffer Read data parity
+    ha0_bwvalid           : out   std_logic                  ; -- Buffer Write valid
+    ha0_bwtag             : out   std_logic_vector(0 to 7)   ; -- Buffer Write tag
+    ha0_bwtagpar          : out   std_logic                  ; -- Buffer Write tag parity
+    ha0_bwad              : out   std_logic_vector(0 to 5)   ; -- Buffer Write address
+    ha0_bwdata            : out   std_logic_vector(0 to 1023); -- Buffer Write data
+    ha0_bwpar             : out   std_logic_vector(0 to 15)  ; -- Buffer Write data parity
+    -- Response interface
+    ha0_rvalid            : out   std_logic                  ; -- Response valid
+    ha0_rtag              : out   std_logic_vector(0 to 7)   ; -- Response tag
+    ha0_rtagpar           : out   std_logic                  ; -- Response tag parity
+    ha0_rditag            : out   std_logic_vector(0 to 8)   ; -- **New DMA Translation Tag for xlat_* requests
+    ha0_rditagpar         : out   std_logic                  ; -- **New Parity bit for above
+    ha0_response          : out   std_logic_vector(0 to 7)   ; -- Response
+    ha0_response_ext      : out   std_logic_vector(0 to 7)   ; -- **New Response Ext
+    ha0_rpagesize         : out   std_logic_vector(0 to 3)   ; -- **New Command translated Page size.  Provided by PSL to allow
+    ha0_rcachestate       : out   std_logic_vector(0 to 1)   ; -- Response cache state
+    ha0_rcachepos         : out   std_logic_vector(0 to 12)  ; -- Response cache pos
+    ha0_rcredits          : out   std_logic_vector(0 to 8)   ; -- Response credits
+--     ha0_reoa              : out   std_logic_vector(0 to 185);  -- **New unknown width or use
+    -- MMIO interface
+    ha0_mmval             : out   std_logic                  ; -- A valid MMIO is present
+    ha0_mmcfg             : out   std_logic                  ; -- afu descriptor space access
+    ha0_mmrnw             : out   std_logic                  ; -- 1 = read, 0 = write
+    ha0_mmdw              : out   std_logic                  ; -- 1 = doubleword, 0 = word
+    ha0_mmad              : out   std_logic_vector(0 to 23)  ; -- mmio address
+    ha0_mmadpar           : out   std_logic                  ; -- mmio address parity
+    ha0_mmdata            : out   std_logic_vector(0 to 63)  ; -- Write data
+    ha0_mmdatapar         : out   std_logic                  ; -- mmio data parity
+    a0h_mmack             : in    std_logic                  ; -- Write is complete or Read is valid
+    a0h_mmdata            : in    std_logic_vector(0 to 63)  ; -- Read data
+    a0h_mmdatapar         : in    std_logic                  ; -- mmio data parity
+    -- Control interface
+    ha0_jval              : out   std_logic                  ; -- Job valid
+    ha0_jcom              : out   std_logic_vector(0 to 7)   ; -- Job command
+    ha0_jcompar           : out   std_logic                  ; -- Job command parity
+    ha0_jea               : out   std_logic_vector(0 to 63)  ; -- Job address
+    ha0_jeapar            : out   std_logic                  ; -- Job address parity
+--  ha0_lop               : out   std_logic_vector(0 to 4)   ; -- LPC/Internal Cache Op code
+--  ha0_loppar            : out   std_logic                  ; -- Job address parity
+--  ha0_lsize             : out   std_logic_vector(0 to 6)   ; -- Size/Secondary Op code
+--  ha0_ltag              : out   std_logic_vector(0 to 11)  ; -- LPC Tag/Internal Cache Tag
+--  ha0_ltagpar           : out   std_logic                  ; -- LPC Tag/Internal Cache Tag parity
+    a0h_jrunning          : in    std_logic                  ; -- Job running
+    a0h_jdone             : in    std_logic                  ; -- Job done
+    a0h_jcack             : in    std_logic                  ; -- completion of llcmd
+    a0h_jerror            : in    std_logic_vector(0 to 63)  ; -- Job error
+-- AM. Sept08, 2016                  a0h_jyield          : inx std_logic                  ; -- Job yield
+--  a0h_ldone             : in    std_logic                  ; -- LPC/Internal Cache Op done
+--  a0h_ldtag             : in    std_logic_vector(0 to 11)  ; -- ltag is done
+--  a0h_ldtagpar          : in    std_logic                  ; -- ldtag parity
+--  a0h_lroom             : in    std_logic_vector(0 to 7)   ; -- LPC/Internal Cache Op AFU can handle
+    a0h_tbreq             : in    std_logic                  ; -- Timebase command request
+    a0h_paren             : in    std_logic                  ; -- parity enable
+    ha0_pclock            : out   std_logic                  ;
+
+-- New DMA Interface
+    -- Port 0
+    -- DMA port 0 Request interface
+    d0h_dvalid            : in    std_logic                  ; -- New PSL/AFU interface
+    d0h_req_utag          : in    std_logic_vector(0 to 9)   ; -- New PSL/AFU interface
+    d0h_req_itag          : in    std_logic_vector(0 to 8)   ; -- New PSL/AFU interface
+    d0h_dtype             : in    std_logic_vector(0 to 2)   ; -- New PSL/AFU interface
+    d0h_datomic_op        : in    std_logic_vector(0 to 5)   ; -- New PSL/AFU interface
+    d0h_datomic_le        : in    std_logic                  ; -- New PSL/AFU interface
+    d0h_dsize             : in    std_logic_vector(0 to 9)   ; -- New PSL/AFU interface
+    d0h_ddata             : in    std_logic_vector(0 to 1023); -- New PSL/AFU interface
+--    d0h_dpar              : in    std_logic_vector(0 to 15)  ; -- New PSL/AFU interface
+    -- DMA port 0 Sent interface
+    hd0_sent_utag_valid   : out   std_logic                  ;
+    hd0_sent_utag         : out   std_logic_vector(0 to 9)   ;
+    hd0_sent_utag_sts     : out   std_logic_vector(0 to 2)   ;
+    -- DMA port 0 Completion interface
+    hd0_cpl_valid         : out   std_logic                  ;
+    hd0_cpl_utag          : out   std_logic_vector(0 to 9)   ;
+    hd0_cpl_type          : out   std_logic_vector(0 to 2)   ;
+    hd0_cpl_laddr         : out   std_logic_vector(0 to 6)   ;
+    hd0_cpl_byte_count    : out   std_logic_vector(0 to 9)   ;
+    hd0_cpl_size          : out   std_logic_vector(0 to 9)   ;
+    hd0_cpl_data          : out   std_logic_vector(0 to 1023);
+--    hd0_cpl_dpar          : out   std_logic_vector(0 to 15);
+
+    gold_factory          : in    std_logic;
+
+    pci_user_reset        : out   std_logic;  --PCI hip user_reset signal if required
+    pci_clock_125MHz      : out   std_logic   --125MHz clock if required
+);
+
+END capi_bsp;
+
+ARCHITECTURE capi_bsp OF capi_bsp IS
+
+
+-- OBUF: Output Buffer
+-- UltraScale
+-- Xilinx HDL Libraries Guide, version 2015.4
+Component OBUF
+    PORT (O : out std_logic;
+          I : in std_logic);
+End Component OBUF;
+
+-- Component pcie4_uscale_plus_0
+Component pcie4_uscale_plus_0
+  PORT(
+    pci_exp_txn : out STD_LOGIC_VECTOR (15 downto 0);
+    pci_exp_txp : out STD_LOGIC_VECTOR (15 downto 0);
+    pci_exp_rxn : in STD_LOGIC_VECTOR (15 downto 0);
+    pci_exp_rxp : in STD_LOGIC_VECTOR (15 downto 0);
+    user_clk : out STD_LOGIC;
+    user_reset : out STD_LOGIC;
+    user_lnk_up : out STD_LOGIC;
+    s_axis_rq_tdata : in STD_LOGIC_VECTOR ( 511 downto 0 );
+    s_axis_rq_tkeep : in STD_LOGIC_VECTOR ( 15 downto 0 );
+    s_axis_rq_tlast : in STD_LOGIC;
+    s_axis_rq_tready : out STD_LOGIC_VECTOR ( 3 downto 0 );
+    s_axis_rq_tuser : in STD_LOGIC_VECTOR ( 136 downto 0 );
+    s_axis_rq_tvalid : in STD_LOGIC;
+    m_axis_rc_tdata : out STD_LOGIC_VECTOR ( 511 downto 0 );
+    m_axis_rc_tkeep : out STD_LOGIC_VECTOR ( 15 downto 0 );
+    m_axis_rc_tlast : out STD_LOGIC;
+    m_axis_rc_tready : in STD_LOGIC_VECTOR ( 0 downto 0 );
+    m_axis_rc_tuser : out STD_LOGIC_VECTOR ( 160 downto 0 );
+    m_axis_rc_tvalid : out STD_LOGIC;
+    m_axis_cq_tdata : out STD_LOGIC_VECTOR ( 511 downto 0 );
+    m_axis_cq_tkeep : out STD_LOGIC_VECTOR ( 15 downto 0 );
+    m_axis_cq_tlast : out STD_LOGIC;
+    m_axis_cq_tready : in STD_LOGIC_VECTOR ( 0 downto 0 );
+    m_axis_cq_tuser : out STD_LOGIC_VECTOR ( 182 downto 0 );
+    m_axis_cq_tvalid : out STD_LOGIC;
+    s_axis_cc_tdata : in STD_LOGIC_VECTOR ( 511 downto 0 );
+    s_axis_cc_tkeep : in STD_LOGIC_VECTOR ( 15 downto 0 );
+    s_axis_cc_tlast : in STD_LOGIC;
+    s_axis_cc_tready : out STD_LOGIC_VECTOR ( 3 downto 0 );
+    s_axis_cc_tuser : in STD_LOGIC_VECTOR ( 80 downto 0 );
+    s_axis_cc_tvalid : in STD_LOGIC;
+    pcie_rq_seq_num0 : out STD_LOGIC_VECTOR ( 5 downto 0 );
+    pcie_rq_seq_num_vld0 : out STD_LOGIC;
+    pcie_rq_seq_num1 : out STD_LOGIC_VECTOR ( 5 downto 0 );
+    pcie_rq_seq_num_vld1 : out STD_LOGIC;
+    pcie_rq_tag0 : out STD_LOGIC_VECTOR ( 7 downto 0 );
+    pcie_rq_tag1 : out STD_LOGIC_VECTOR ( 7 downto 0 );
+    pcie_rq_tag_av : out STD_LOGIC_VECTOR ( 3 downto 0 );
+    pcie_rq_tag_vld0 : out STD_LOGIC;
+    pcie_rq_tag_vld1 : out STD_LOGIC;
+    pcie_tfc_nph_av : out STD_LOGIC_VECTOR ( 3 downto 0 );
+    pcie_tfc_npd_av : out STD_LOGIC_VECTOR ( 3 downto 0 );
+    pcie_cq_np_req : in STD_LOGIC_VECTOR ( 1 downto 0 );
+    pcie_cq_np_req_count : out STD_LOGIC_VECTOR ( 5 downto 0 );
+    cfg_phy_link_down : out STD_LOGIC;
+    cfg_phy_link_status : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_negotiated_width : out STD_LOGIC_VECTOR ( 2 downto 0 );
+    cfg_current_speed : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_max_payload : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_max_read_req : out STD_LOGIC_VECTOR ( 2 downto 0 );
+    cfg_function_status : out STD_LOGIC_VECTOR ( 15 downto 0 );
+    cfg_function_power_state : out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_vf_status : out STD_LOGIC_VECTOR ( 503 downto 0 );
+    cfg_vf_power_state : out STD_LOGIC_VECTOR ( 755 downto 0 );
+    cfg_link_power_state : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_mgmt_addr : in STD_LOGIC_VECTOR ( 9 downto 0 );
+    cfg_mgmt_function_number : in STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_mgmt_write : in STD_LOGIC;
+    cfg_mgmt_write_data : in STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_mgmt_byte_enable : in STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_mgmt_read : in STD_LOGIC;
+    cfg_mgmt_read_data : out STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_mgmt_read_write_done : out STD_LOGIC;
+    cfg_mgmt_debug_access : in STD_LOGIC;
+    cfg_err_cor_out : out STD_LOGIC;
+    cfg_err_nonfatal_out : out STD_LOGIC;
+    cfg_err_fatal_out : out STD_LOGIC;
+    cfg_local_error_valid : out STD_LOGIC;
+--    cfg_ltr_enable : out STD_LOGIC;
+    cfg_local_error_out : out STD_LOGIC_VECTOR ( 4 downto 0 );
+    cfg_ltssm_state : out STD_LOGIC_VECTOR ( 5 downto 0 );
+    cfg_rx_pm_state : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_tx_pm_state : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_rcb_status : out STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_obff_enable : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_pl_status_change : out STD_LOGIC;
+    cfg_tph_requester_enable : out STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_tph_st_mode : out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_vf_tph_requester_enable : out STD_LOGIC_VECTOR ( 251 downto 0 );
+    cfg_vf_tph_st_mode : out STD_LOGIC_VECTOR ( 755 downto 0 );
+    cfg_msg_received : out STD_LOGIC;
+    cfg_msg_received_data : out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_msg_received_type : out STD_LOGIC_VECTOR ( 4 downto 0 );
+    cfg_msg_transmit : in STD_LOGIC;
+    cfg_msg_transmit_type : in STD_LOGIC_VECTOR ( 2 downto 0 );
+    cfg_msg_transmit_data : in STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_msg_transmit_done : out STD_LOGIC;
+    cfg_fc_ph : out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_fc_pd : out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_fc_nph : out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_fc_npd : out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_fc_cplh : out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_fc_cpld : out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_fc_sel : in STD_LOGIC_VECTOR ( 2 downto 0 );
+    cfg_dsn : in STD_LOGIC_VECTOR ( 63 downto 0 );
+    cfg_bus_number : out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_power_state_change_ack : in STD_LOGIC;
+    cfg_power_state_change_interrupt : out STD_LOGIC;
+    cfg_err_cor_in : in STD_LOGIC;
+    cfg_err_uncor_in : in STD_LOGIC;
+    cfg_flr_in_process : out STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_flr_done : in STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_vf_flr_in_process : out STD_LOGIC_VECTOR ( 251 downto 0 );
+    cfg_vf_flr_func_num : in STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_vf_flr_done : in STD_LOGIC_VECTOR ( 0 to 0 );
+    cfg_link_training_enable : in STD_LOGIC;
+    cfg_ext_read_received : out STD_LOGIC;
+    cfg_ext_write_received : out STD_LOGIC;
+    cfg_ext_register_number : out STD_LOGIC_VECTOR ( 9 downto 0 );
+    cfg_ext_function_number : out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_ext_write_data : out STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_ext_write_byte_enable : out STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_ext_read_data : in STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_ext_read_data_valid : in STD_LOGIC;
+    cfg_interrupt_int : in STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_interrupt_pending : in STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_interrupt_sent : out STD_LOGIC;
+
+    cfg_interrupt_msi_enable : out STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_interrupt_msi_mmenable : out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_interrupt_msi_mask_update : out STD_LOGIC;
+    cfg_interrupt_msi_data : out STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_interrupt_msi_select : in STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_interrupt_msi_int : in STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_interrupt_msi_pending_status : in STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_interrupt_msi_pending_status_data_enable : in STD_LOGIC;
+    cfg_interrupt_msi_pending_status_function_num : in STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_interrupt_msi_sent : out STD_LOGIC;
+    cfg_interrupt_msi_fail : out STD_LOGIC;
+    cfg_interrupt_msi_attr : in STD_LOGIC_VECTOR ( 2 downto 0 );
+    cfg_interrupt_msi_tph_present : in STD_LOGIC;
+    cfg_interrupt_msi_tph_type : in STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_interrupt_msi_tph_st_tag : in STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_interrupt_msi_function_number : in STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_pm_aspm_l1_entry_reject : in STD_LOGIC;
+    cfg_pm_aspm_tx_l0s_entry_disable : in STD_LOGIC;
+    cfg_hot_reset_out : out STD_LOGIC;
+    cfg_config_space_enable : in STD_LOGIC;
+    cfg_req_pm_transition_l23_ready : in STD_LOGIC;
+    cfg_hot_reset_in : in STD_LOGIC;
+    cfg_ds_port_number : in STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_ds_bus_number : in STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_ds_device_number : in STD_LOGIC_VECTOR ( 4 downto 0 );
+
+--    cfg_pm_aspm_l1_entry_reject : in STD_LOGIC;
+--    cfg_pm_aspm_tx_l0s_entry_disable : in STD_LOGIC;
+--    cfg_hot_reset_out : out STD_LOGIC;
+--    cfg_config_space_enable : in STD_LOGIC;
+--    cfg_req_pm_transition_l23_ready : in STD_LOGIC;
+--    cfg_hot_reset_in : in STD_LOGIC;
+--    cfg_ds_port_number : in STD_LOGIC_VECTOR ( 7 downto 0 );
+--    cfg_ds_bus_number : in STD_LOGIC_VECTOR ( 7 downto 0 );
+--    cfg_ds_device_number : in STD_LOGIC_VECTOR ( 4 downto 0 );
+--    cfg_ds_function_number : in STD_LOGIC_VECTOR ( 2 downto 0 );
+--    cfg_subsys_vend_id : in STD_LOGIC_VECTOR ( 15 downto 0 );
+--    cfg_dev_id_pf0 : in STD_LOGIC_VECTOR ( 15 downto 0 );
+----    cfg_dev_id_pf1 : in STD_LOGIC_VECTOR ( 15 downto 0 );
+----    cfg_dev_id_pf2 : in STD_LOGIC_VECTOR ( 15 downto 0 );
+----    cfg_dev_id_pf3 : in STD_LOGIC_VECTOR ( 15 downto 0 );
+--    cfg_vend_id : in STD_LOGIC_VECTOR ( 15 downto 0 );
+--    cfg_rev_id_pf0 : in STD_LOGIC_VECTOR ( 7 downto 0 );
+----    cfg_rev_id_pf1 : in STD_LOGIC_VECTOR ( 7 downto 0 );
+----    cfg_rev_id_pf2 : in STD_LOGIC_VECTOR ( 7 downto 0 );
+----    cfg_rev_id_pf3 : in STD_LOGIC_VECTOR ( 7 downto 0 );
+--    cfg_subsys_id_pf0 : in STD_LOGIC_VECTOR ( 15 downto 0 );
+--    cfg_subsys_id_pf1 : in STD_LOGIC_VECTOR ( 15 downto 0 );
+--    cfg_subsys_id_pf2 : in STD_LOGIC_VECTOR ( 15 downto 0 );
+--    cfg_subsys_id_pf3 : in STD_LOGIC_VECTOR ( 15 downto 0 );
+
+    sys_clk : in STD_LOGIC;
+    sys_clk_gt : in STD_LOGIC;
+    sys_reset : in STD_LOGIC;
+    phy_rdy_out : out STD_LOGIC
+
+ -- New for 2016.4
+    --int_qpll0lock_out : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    --int_qpll0outrefclk_out : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    --int_qpll0outclk_out : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    --int_qpll1lock_out : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    --int_qpll1outrefclk_out : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    --int_qpll1outclk_out : out STD_LOGIC_VECTOR ( 1 downto 0 )
+
+  );
+
+end Component pcie4_uscale_plus_0;
+
+-- IBUFDS_GTE4: Gigabit Transceiver Buffer
+-- UltraScale
+-- Xilinx HDL Libraries Guide, version 2015.4
+
+Component IBUFDS_GTE4
+-- generic(
+-- REFCLK_EN_TX_PATH : in std_logic;
+-- REFCLK_HROW_CK_SEL : in std_logic_vector(0 to 1);
+-- REFCLK_ICNTL_RX  : in std_logic_vector(0 to 1)
+-- );
+PORT
+    (O : out STD_LOGIC;
+              ODIV2                                          : out   STD_LOGIC;
+              I                                              : in    STD_LOGIC;
+              CEB                                            : in    STD_LOGIC;
+     IB : in STD_LOGIC
+);
+end Component IBUFDS_GTE4;
+
+Component IBUF
+PORT (
+              O                                              : out   STD_LOGIC;
+I : in  STD_LOGIC
+);
+end Component IBUF;
+
+Component uscale_plus_clk_wiz
+PORT (
+              clk_in1                                        : in    STD_LOGIC;
+              clk_out1                                       : out   STD_LOGIC;
+              clk_out2                                       : out   STD_LOGIC;
+              clk_out3                                       : out   STD_LOGIC;
+              clk_out3_ce                                    : in    STD_LOGIC;
+              reset                                          : in    STD_LOGIC;
+    locked : out STD_LOGIC
+  );
+end Component uscale_plus_clk_wiz;
+
+-- Component capi_fpga_reset
+Component CAPI_FPGA_RESET_GEN
+  PORT(PLL_LOCKED    : in  std_logic;
+              CLK                                            : in    std_logic;
+       RESET     : out std_logic);
+End Component CAPI_FPGA_RESET_GEN;
+
+-- Component capi_stp_counter
+Component CAPI_STP_COUNTER
+  PORT(CLK     : in  std_logic;
+              RESET                                          : in    std_logic;
+              STP_COUNTER_1sec                               : out   std_logic;
+       STP_COUNTER_MSB  : out std_logic);
+End Component CAPI_STP_COUNTER;
+
+-- Component psl
+Component PSL9_WRAP_0
+--Component PSL9_WRAP
+  PORT(
+------        psl_clk: in std_logic;
+------        psl_rst: in std_logic;
+------        pcihip0_psl_clk: in std_logic;
+------        pcihip0_psl_rst: in std_logic;
+------        crc_error: in std_logic;
+              a0h_cvalid                                     : in    std_logic;
+              a0h_ctag                                       : in    std_logic_vector(0 to 7);
+              a0h_com                                        : in    std_logic_vector(0 to 12);
+------        a0h_cpad: in std_logic_vector(0 to 2);
+              a0h_cabt                                       : in    std_logic_vector(0 to 2);
+              a0h_cea                                        : in    std_logic_vector(0 to 63);
+              a0h_cch                                        : in    std_logic_vector(0 to 15);
+              a0h_csize                                      : in    std_logic_vector(0 to 11);
+              a0h_cpagesize                                  : in    std_logic_vector(0 to 3);
+              ha0_croom                                      : out   std_logic_vector(0 to 7);
+              a0h_ctagpar                                    : in    std_logic;
+              a0h_compar                                     : in    std_logic;
+              a0h_ceapar                                     : in    std_logic;
+              ha0_brvalid                                    : out   std_logic;
+              ha0_brtag                                      : out   std_logic_vector(0 to 7);
+              ha0_brad                                       : out   std_logic_vector(0 to 5);
+              a0h_brlat                                      : in    std_logic_vector(0 to 3);
+              a0h_brdata                                     : in    std_logic_vector(0 to 1023);
+              a0h_brpar                                      : in    std_logic_vector(0 to 15);
+              ha0_bwvalid                                    : out   std_logic;
+              ha0_bwtag                                      : out   std_logic_vector(0 to 7);
+              ha0_bwad                                       : out   std_logic_vector(0 to 5);
+              ha0_bwdata                                     : out   std_logic_vector(0 to 1023);
+              ha0_bwpar                                      : out   std_logic_vector(0 to 15);
+              ha0_brtagpar                                   : out   std_logic;
+              ha0_bwtagpar                                   : out   std_logic;
+              ha0_rvalid                                     : out   std_logic;
+              ha0_rtag                                       : out   std_logic_vector(0 to 7);
+              ha0_rtagpar                                    : out   std_logic;
+              ha0_rditag                                     : out   std_logic_vector(0 to 8);
+              ha0_rditagpar                                  : out   std_logic;
+              ha0_response                                   : out   std_logic_vector(0 to 7);
+              ha0_response_ext                               : out   std_logic_vector(0 to 7);
+              ha0_rpagesize                                  : out   std_logic_vector(0 to 3);
+              ha0_rcredits                                   : out   std_logic_vector(0 to 8);
+              ha0_rcachestate                                : out   std_logic_vector(0 to 1);
+              ha0_rcachepos                                  : out   std_logic_vector(0 to 12);
+              ha0_reoa                                       : out   std_logic_vector(0 to 185);
+
+              ha0_mmval                                      : out   std_logic;
+              ha0_mmcfg                                      : out   std_logic;
+              ha0_mmrnw                                      : out   std_logic;
+              ha0_mmdw                                       : out   std_logic;
+              ha0_mmad                                       : out   std_logic_vector(0 to 23);
+              ha0_mmadpar                                    : out   std_logic;
+              ha0_mmdata                                     : out   std_logic_vector(0 to 63);
+              ha0_mmdatapar                                  : out   std_logic;
+              a0h_mmack                                      : in    std_logic;
+              a0h_mmdata                                     : in    std_logic_vector(0 to 63);
+              a0h_mmdatapar                                  : in    std_logic;
+
+              ha0_jval                                       : out   std_logic;
+              ha0_jcom                                       : out   std_logic_vector(0 to 7);
+              ha0_jcompar                                    : out   std_logic;
+              ha0_jea                                        : out   std_logic_vector(0 to 63);
+              ha0_jeapar                                     : out   std_logic;
+              a0h_jrunning                                   : in    std_logic;
+              a0h_jdone                                      : in    std_logic;
+              a0h_jcack                                      : in    std_logic;
+              a0h_jerror                                     : in    std_logic_vector(0 to 63);
+--        a0h_jyield: in std_logic;
+              a0h_tbreq                                      : in    std_logic;
+              a0h_paren                                      : in    std_logic;
+              ha0_pclock                                     : out   std_logic;
+
+
+              D0H_DVALID                                     : in    std_logic;
+              D0H_REQ_UTAG                                   : in    std_logic_vector(0 to 9);
+              D0H_REQ_ITAG                                   : in    std_logic_vector(0 to 8);
+              D0H_DTYPE                                      : in    std_logic_vector(0 to 2);
+--         DH_DRELAXED:in  std_logic;
+              D0H_DATOMIC_OP                                 : in    std_logic_vector(0 to 5);
+              D0H_DATOMIC_LE                                 : in    std_logic                    ;-- New PSL/AFU interface
+              D0H_DSIZE                                      : in    std_logic_vector(0 to 9);
+              D0H_DDATA                                      : in    std_logic_vector(0 to 1023);
+--         D0H_DPAR: in std_logic_vector(0 to 15);
+--         // ----------------------------------------------------------------------------------------------------------------------
+--         // ----------------------------
+--         // PSL DMA Completion Interface
+--         // ----------------------------
+              HD0_CPL_VALID                                  : out   std_logic;
+              HD0_CPL_UTAG                                   : out   std_logic_vector(0 to 9);
+              HD0_CPL_TYPE                                   : out   std_logic_vector(0 to 2);
+              HD0_CPL_LADDR                                  : out   std_logic_vector(0 to 6);
+              HD0_CPL_BYTE_COUNT                             : out   std_logic_vector(0 to 9);
+              HD0_CPL_SIZE                                   : out   std_logic_vector(0 to 9);
+              HD0_CPL_DATA                                   : out   std_logic_vector(0 to 1023);
+--         HD0_CPL_DPAR : out std_logic_vector(0 to 15);
+--         // ----------------------------------------------------------------------------------------------------------------------
+--         // ----------------------
+--         // PSL DMA Sent Interface
+--         // ----------------------
+              HD0_SENT_UTAG_VALID                            : out   std_logic;
+              HD0_SENT_UTAG                                  : out   std_logic_vector(0 to 9);
+              HD0_SENT_UTAG_STS                              : out   std_logic_vector(0 to 2);
+
+
+
+              AXIS_CQ_TVALID                                 : in    std_logic;
+              AXIS_CQ_TDATA                                  : in    std_logic_vector(511 downto 0);
+              AXIS_CQ_TREADY                                 : out   std_logic;
+              AXIS_CQ_TUSER                                  : in    std_logic_vector(182 downto 0);
+              AXIS_CQ_NP_REQ                                 : out   std_logic_vector(1 downto 0);
+--         //XLX IP RC Interface
+              AXIS_RC_TVALID                                 : in    std_logic;
+              AXIS_RC_TDATA                                  : in    std_logic_vector(511 downto 0);
+              AXIS_RC_TREADY                                 : out   std_logic;
+              AXIS_RC_TUSER                                  : in    std_logic_vector(160 downto 0);
+--         //-----------------------------------------------------------------------------------------------------------------------
+--         //XLX IP RQ Interface
+              AXIS_RQ_TVALID                                 : out   std_logic;
+              AXIS_RQ_TDATA                                  : out   std_logic_vector(511 downto 0);
+              AXIS_RQ_TREADY                                 : in    std_logic;
+              AXIS_RQ_TLAST                                  : out   std_logic;
+              AXIS_RQ_TUSER                                  : out   std_logic_vector(136 downto 0);
+              AXIS_RQ_TKEEP                                  : out   std_logic_vector(15 downto 0);
+--         //XLX IP CC Interface
+              AXIS_CC_TVALID                                 : out   std_logic;
+              AXIS_CC_TDATA                                  : out   std_logic_vector(511 downto 0);
+              AXIS_CC_TREADY                                 : in    std_logic;
+              AXIS_CC_TLAST                                  : out   std_logic;
+              AXIS_CC_TUSER                                  : out   std_logic_vector(80 downto 0);
+              AXIS_CC_TKEEP                                  : out   std_logic_vector(15 downto 0);
+--         //----------------------------------------------------------------------------------------------------------------------
+--         // Configuration Interface
+--         // cfg_fc_sel[2:0] = 101b, cfg_fc_ph[7:0], cfg_fc_pd[11:0] cfg_fc_nph[7:0]
+              XIP_CFG_FC_SEL                                 : out   std_logic_vector(2 downto 0);
+              XIP_CFG_FC_PH                                  : in    std_logic_vector(7 downto 0);
+              XIP_CFG_FC_PD                                  : in    std_logic_vector(11 downto 0);
+              XIP_CFG_FC_NP                                  : in    std_logic_vector(7 downto 0);
+
+              psl_kill_link                                  : out   std_logic;
+              psl_build_ver                                  : in    std_logic_vector(0 to 31);
+              afu_clk                                        : in    std_logic;
+
+              PSL_RST                                        : in    std_logic;
+              PSL_CLK                                        : in    std_logic;
+              PCIHIP_PSL_RST                                 : in    std_logic;
+        PCIHIP_PSL_CLK : in std_logic
+
+);
+-- End Component psl;
+End Component PSL9_WRAP_0;
+--End Component PSL9_WRAP;
+
+-- CAPI board infrastructure
+Component capi_board_infrastructure
+  PORT(
+              cfg_ext_read_received                          : IN    STD_LOGIC;
+              cfg_ext_write_received                         : IN    STD_LOGIC;
+              cfg_ext_register_number                        : IN    STD_LOGIC_VECTOR(9 DOWNTO 0);
+              cfg_ext_function_number                        : IN    STD_LOGIC_VECTOR(7 DOWNTO 0);
+              cfg_ext_write_data                             : IN    STD_LOGIC_VECTOR(31 DOWNTO 0);
+              cfg_ext_write_byte_enable                      : IN    STD_LOGIC_VECTOR(3 DOWNTO 0);
+              cfg_ext_read_data                              : OUT   STD_LOGIC_VECTOR(31 DOWNTO 0);
+              cfg_ext_read_data_valid                        : OUT   STD_LOGIC;
+
+     --    spi_miso_secondary            : in    std_logic;
+     --    spi_mosi_secondary            : out   std_logic;
+     --    spi_cen_secondary             : out   std_logic;
+
+              pci_pi_nperst0                                 : in    std_logic;
+              pcihip0_psl_clk                                : in    std_logic;
+              icap_clk                                       : in    std_logic;
+              cpld_usergolden                                : in    std_logic                     ;  -- bool
+              crc_error                                      : out   std_logic
+               );
+END Component capi_board_infrastructure;
+
+Component capi_rise_dff
+  PORT (clk   : in std_logic;
+        dout  : out std_logic;
+        din   : in std_logic);
+End Component capi_rise_dff;
+
+attribute mark_debug : string;
+Signal ha0_reoa: std_logic_vector(0 to 185);
+
+Signal hip_npor0: std_logic;  -- bool
+Signal i_cpld_sda: std_logic;  -- bool
+Signal crc_error: std_logic;  -- bool
+Signal i_therm_sda: std_logic;  -- bool
+Signal i_ucd_sda: std_logic;  -- bool
+-- Apr13 Signal pcihip0_psl_app_int_ack: std_logic;  -- bool
+-- Apr13 Signal pcihip0_psl_app_msi_ack: std_logic;  -- bool
+-- Apr13 Signal pcihip0_psl_cfg_par_err: std_logic;  -- bool
+Signal pcihip0_psl_coreclkout_hip: std_logic;  -- bool
+Signal pcihip0_psl_cseb_addr: std_logic_vector(0 to 32);  -- v33bit
+Signal pcihip0_psl_cseb_addr_parity: std_logic_vector(0 to 4);  -- v5bit
+Signal pcihip0_psl_cseb_be: std_logic_vector(0 to 3);  -- v4bit
+Signal pcihip0_psl_cseb_rden: std_logic;  -- bool
+Signal pcihip0_psl_cseb_wrdata: std_logic_vector(0 to 31);  -- v32bit
+Signal pcihip0_psl_cseb_wrdata_parity: std_logic_vector(0 to 3);  -- v4bit
+Signal pcihip0_psl_cseb_wren: std_logic;  -- bool
+Signal pcihip0_psl_cseb_wrresp_req: std_logic;  -- bool
+-- Apr13 Signal pcihip0_psl_derr_cor_ext_rcv: std_logic;  -- bool
+-- Apr13 Signal pcihip0_psl_derr_cor_ext_rpl: std_logic;  -- bool
+-- Apr13 Signal pcihip0_psl_derr_rpl: std_logic;  -- bool
+-- Apr13 Signal pcihip0_psl_hip_reconfig_readdata: std_logic_vector(0 to 15);  -- v16bit
+-- Apr13 Signal pcihip0_psl_ko_cpl_spc_data: std_logic_vector(0 to 11);  -- v12bit
+-- Apr13 Signal pcihip0_psl_ko_cpl_spc_header: std_logic_vector(0 to 7);  -- v8bit
+-- Apr13 Signal pcihip0_psl_lmi_ack: std_logic;  -- bool
+-- Apr13 Signal pcihip0_psl_lmi_dout: std_logic_vector(0 to 31);  -- v32bit
+Signal pcihip0_psl_pld_clk_inuse: std_logic;  -- bool
+-- Apr13 Signal pcihip0_psl_pme_to_sr: std_logic;  -- bool
+Signal pcihip0_psl_reset_status: std_logic;  -- bool
+-- Apr13 Signal pcihip0_psl_rx_par_err: std_logic;  -- bool
+Signal pcihip0_psl_rx_st_bar: std_logic_vector(0 to 7);  -- v8bit
+Signal pcihip0_psl_rx_st_data: std_logic_vector(0 to 255);  -- v256bit
+Signal pcihip0_psl_rx_st_empty: std_logic_vector(0 to 1);  -- v2bit
+Signal pcihip0_psl_rx_st_eop: std_logic;  -- bool
+Signal pcihip0_psl_rx_st_err: std_logic;  -- bool
+Signal pcihip0_psl_rx_st_parity: std_logic_vector(0 to 31);  -- v32bit
+Signal pcihip0_psl_rx_st_sop: std_logic;  -- bool
+Signal pcihip0_psl_rx_st_valid: std_logic;  -- bool
+-- Apr13 Signal pcihip0_psl_testin_zero: std_logic;  -- bool
+Signal pcihip0_psl_tl_cfg_add: std_logic_vector(0 to 3);  -- v4bit
+Signal pcihip0_psl_tl_cfg_ctl: std_logic_vector(0 to 31);  -- v32bit
+-- Apr13 Signal pcihip0_psl_tl_cfg_sts: std_logic_vector(0 to 52);  -- v53bit
+Signal pcihip0_psl_tx_cred_datafccp: std_logic_vector(0 to 11);  -- v12bit
+Signal pcihip0_psl_tx_cred_datafcnp: std_logic_vector(0 to 11);  -- v12bit
+Signal pcihip0_psl_tx_cred_datafcp: std_logic_vector(0 to 11);  -- v12bit
+Signal pcihip0_psl_tx_cred_fchipcons: std_logic_vector(0 to 5);  -- v6bit
+Signal pcihip0_psl_tx_cred_fcinfinite: std_logic_vector(0 to 5);  -- v6bit
+Signal pcihip0_psl_tx_cred_hdrfccp: std_logic_vector(0 to 7);  -- v8bit
+Signal pcihip0_psl_tx_cred_hdrfcnp: std_logic_vector(0 to 7);  -- v8bit
+Signal pcihip0_psl_tx_cred_hdrfcp: std_logic_vector(0 to 7);  -- v8bit
+-- Apr13 Signal pcihip0_psl_tx_par_err: std_logic_vector(0 to 1);  -- v2bit
+Signal pcihip0_psl_tx_st_ready: std_logic;  -- bool
+Signal psl_clk: std_logic;  -- bool
+Signal psl_clk_div2: std_logic;  -- bool
+
+Signal sys_clk_p   : std_logic ;
+Signal sys_clk_n   : std_logic ;
+Signal sys_rst_n   : std_logic ;
+Signal pci_exp_txn : STD_LOGIC_VECTOR (15 downto 0);
+Signal pci_exp_txp : STD_LOGIC_VECTOR (15 downto 0);
+Signal pci_exp_rxn : STD_LOGIC_VECTOR (15 downto 0);
+Signal pci_exp_rxp : STD_LOGIC_VECTOR (15 downto 0);
+
+signal        psl_reset_sig : std_logic;
+signal        axis_cq_tvalid : std_logic;
+signal        axis_cq_tdata  : std_logic_vector(511 downto 0);
+signal        axis_cq_tready : std_logic;
+signal        axis_cq_tready_22 : std_logic_vector(0 downto 0);
+signal        axis_cq_tuser  : std_logic_vector(182 downto 0);
+signal        axis_cq_np_req : std_logic_vector(1 downto 0);
+--         //XLX IP RC Interface
+signal        axis_rc_tvalid  : std_logic;
+signal        axis_rc_tdata   : std_logic_vector(511 downto 0);
+signal        axis_rc_tready  : std_logic;
+-- signal        axis_rc_tready_22  : std_logic_vector(0 downto 0);
+signal        axis_rc_tready_22  : std_logic;
+signal        axis_rc_tuser   : std_logic_vector(160 downto 0);
+--         //-----------------------------------------------------------------------------------------------------------------------
+--         //XLX IP RQ Interface
+signal        axis_rq_tvalid  : std_logic;
+signal        axis_rq_tdata   : std_logic_vector(511 downto 0);
+signal        axis_rq_tready  : std_logic_vector(3 downto 0);
+signal        axis_rq_tlast   : std_logic;
+signal        axis_rq_tuser   : std_logic_vector(136 downto 0);
+signal        axis_rq_tkeep   : std_logic_vector(15 downto 0);
+--         //XLX IP CC Interface
+signal        axis_cc_tvalid  : std_logic;
+signal        axis_cc_tdata   : std_logic_vector(511 downto 0);
+signal        axis_cc_tready  : std_logic_vector(3 downto 0);
+signal        axis_cc_tlast   : std_logic;
+signal        axis_cc_tuser   : std_logic_vector(80 downto 0);
+signal        axis_cc_tkeep   : std_logic_vector(15 downto 0);
+
+Signal pcihip0_psl_clk  : std_logic;
+Signal pcihip0_psl_rst  : std_logic;
+Signal user_lnk_up  : std_logic;
+
+Signal xip_cfg_fc_sel_sig   : std_logic_vector(2 downto 0);
+Signal xip_cfg_fc_ph_sig    : std_logic_vector(7 downto 0);
+Signal xip_cfg_fc_pd_sig    : std_logic_vector(11 downto 0);
+Signal xip_cfg_fc_np_sig    : std_logic_vector(7 downto 0);
+Signal cfg_dsn_sig  : std_logic_vector(63 downto 0);
+
+Signal sys_clk    : std_logic;
+Signal sys_clk_gt   : std_logic;
+Signal sys_rst_n_c   : std_logic;
+
+Signal stp_counter_msb_sig : std_logic;
+Signal stp_counter_1sec_sig : std_logic;
+Signal sys_clk_counter_1sec_sig : std_logic;
+Signal user_clock_sig  : std_logic;
+
+signal clk_wiz_2_locked : std_logic;
+
+signal efes32             : std_logic_vector(31 downto 0);
+--signal efes1024           : std_logic_vector(1023 downto 0);
+signal one1             : std_logic;
+signal two2             : std_logic_vector(1 downto 0);
+
+signal psl_build_ver: std_logic_vector(0 to 31);
+
+Signal icap_clk: std_logic;  -- 125Mhz clock from PCIe refclk
+Signal icap_clk_ce: std_logic;  -- bool
+Signal icap_clk_ce_d: std_logic;
+
+Signal cfg_ext_read_received : STD_LOGIC;
+Signal cfg_ext_write_received : STD_LOGIC;
+Signal cfg_ext_register_number : STD_LOGIC_VECTOR(9 DOWNTO 0);
+Signal cfg_ext_function_number : STD_LOGIC_VECTOR(7 DOWNTO 0);
+Signal cfg_ext_write_data : STD_LOGIC_VECTOR(31 DOWNTO 0);
+Signal cfg_ext_write_byte_enable : STD_LOGIC_VECTOR(3 DOWNTO 0);
+Signal cfg_ext_read_data : STD_LOGIC_VECTOR(31 DOWNTO 0);
+Signal cfg_ext_read_data_valid : STD_LOGIC;
+
+
+Signal led_red : std_logic_vector(3 downto 0);
+Signal led_green : std_logic_vector(3 downto 0);
+Signal led_blue : std_logic_vector(3 downto 0);
+
+begin
+
+-- psl_build_ver   <= x"0000685a";    -- March 15, 2017 With Subsystem ID = x060f for capi_flash script
+psl_build_ver   <= x"00006900";    -- March 22, 2017 With fixes and With Subsystem ID = x060f for capi_flash script
+-- hd0_cpl_laddr <= "000" & hd0_cpl_laddr_0_6;
+
+
+
+    -- PSL logic
+p:  PSL9_WRAP_0
+      PORT MAP (
+-- Apr13         crc_error => crc_errorinternal,
+         a0h_cvalid => a0h_cvalid,
+         a0h_ctag => a0h_ctag,
+         a0h_com => a0h_com,
+-- Apr13         a0h_cpad => a0h_cpad,
+         a0h_cabt => a0h_cabt,
+         a0h_cea => a0h_cea,
+         a0h_cch => a0h_cch,
+         a0h_csize => a0h_csize,
+         a0h_cpagesize => a0h_cpagesize,
+         ha0_croom => ha0_croom,
+         a0h_ctagpar => a0h_ctagpar,
+         a0h_compar => a0h_compar,
+         a0h_ceapar => a0h_ceapar,
+         ha0_brvalid => ha0_brvalid,
+         ha0_brtag => ha0_brtag,
+         ha0_brad => ha0_brad,
+         a0h_brlat => a0h_brlat,
+         a0h_brdata => a0h_brdata,
+         a0h_brpar => a0h_brpar,
+         ha0_bwvalid => ha0_bwvalid,
+         ha0_bwtag => ha0_bwtag,
+         ha0_bwad => ha0_bwad,
+         ha0_bwdata => ha0_bwdata,
+         ha0_bwpar => ha0_bwpar,
+         ha0_brtagpar => ha0_brtagpar,
+         ha0_bwtagpar => ha0_bwtagpar,
+         ha0_rcredits => ha0_rcredits,
+
+         ha0_response_ext => ha0_response_ext,
+         ha0_rditag => ha0_rditag,
+         ha0_rditagpar => ha0_rditagpar,
+         ha0_rpagesize => ha0_rpagesize,
+
+         ha0_rvalid => ha0_rvalid,
+         ha0_rtag => ha0_rtag,
+         ha0_response => ha0_response,
+         ha0_rcachestate => ha0_rcachestate,
+         ha0_rcachepos => ha0_rcachepos,
+         ha0_rtagpar => ha0_rtagpar,
+         ha0_reoa => ha0_reoa,
+
+         ha0_mmval => ha0_mmval,
+         ha0_mmrnw => ha0_mmrnw,
+         ha0_mmdw => ha0_mmdw,
+         ha0_mmad => ha0_mmad,
+         ha0_mmdata => ha0_mmdata,
+         ha0_mmcfg => ha0_mmcfg,
+         a0h_mmack => a0h_mmack,
+         a0h_mmdata => a0h_mmdata,
+         ha0_mmadpar => ha0_mmadpar,
+         ha0_mmdatapar => ha0_mmdatapar,
+         a0h_mmdatapar => a0h_mmdatapar,
+
+         ha0_jval => ha0_jval,
+         ha0_jcom => ha0_jcom,
+         ha0_jea => ha0_jea,
+         a0h_jrunning => a0h_jrunning,
+         a0h_jdone => a0h_jdone,
+         a0h_jcack => a0h_jcack,
+         a0h_jerror => a0h_jerror,
+         a0h_tbreq => a0h_tbreq,
+--          a0h_jyield => a0h_jyield,
+         ha0_jeapar => ha0_jeapar,
+         ha0_jcompar => ha0_jcompar,
+         a0h_paren => a0h_paren,
+         ha0_pclock => ha0_pclock,
+
+        D0H_DVALID => d0h_dvalid,
+        D0H_REQ_UTAG => d0h_req_utag,
+        D0H_REQ_ITAG => d0h_req_itag,
+        D0H_DTYPE => d0h_dtype,
+        D0H_DATOMIC_OP => d0h_datomic_op,
+        D0H_DATOMIC_LE => d0h_datomic_le,
+--        DH_DRELAXED => d0h_drelaxed,
+        D0H_DSIZE => d0h_dsize,
+        D0H_DDATA => d0h_ddata,
+--         D0H_DPAR => d0h_dpar,
+
+        HD0_CPL_VALID => hd0_cpl_valid,
+        HD0_CPL_UTAG => hd0_cpl_utag,
+        HD0_CPL_TYPE => hd0_cpl_type,
+        HD0_CPL_LADDR => hd0_cpl_laddr,
+        HD0_CPL_BYTE_COUNT => hd0_cpl_byte_count,
+        HD0_CPL_SIZE => hd0_cpl_size,
+        HD0_CPL_DATA => hd0_cpl_data,
+--         HD0_CPL_DPAR => hd0_cpl_dpar,
+--
+        HD0_SENT_UTAG_VALID => hd0_sent_utag_valid,
+        HD0_SENT_UTAG => hd0_sent_utag,
+        HD0_SENT_UTAG_STS => hd0_sent_utag_sts,
+
+
+
+
+        AXIS_CQ_TVALID  => axis_cq_tvalid,
+        AXIS_CQ_TDATA   => axis_cq_tdata,
+        AXIS_CQ_TREADY  => axis_cq_tready,
+        AXIS_CQ_TUSER   => axis_cq_tuser,
+        AXIS_CQ_NP_REQ  => axis_cq_np_req,
+--         //XLX IP RC Interface
+        AXIS_RC_TVALID  => axis_rc_tvalid,
+        AXIS_RC_TDATA   => axis_rc_tdata,
+        AXIS_RC_TREADY  => axis_rc_tready,
+        AXIS_RC_TUSER   => axis_rc_tuser,
+--         //-----------------------------------------------------------------------------------------------------------------------
+--         //XLX IP RQ Interface
+        AXIS_RQ_TVALID  => axis_rq_tvalid,
+        AXIS_RQ_TDATA   => axis_rq_tdata,
+        AXIS_RQ_TREADY  => axis_rq_tready(0),  -- AM. TDB
+        AXIS_RQ_TLAST   => axis_rq_tlast,
+        AXIS_RQ_TUSER   => axis_rq_tuser,
+        AXIS_RQ_TKEEP   => axis_rq_tkeep,
+--         //XLX IP CC Interface
+        AXIS_CC_TVALID  => axis_cc_tvalid,
+        AXIS_CC_TDATA   => axis_cc_tdata,
+        AXIS_CC_TREADY  => axis_cc_tready(0),  -- AM. TDB
+        AXIS_CC_TLAST   => axis_cc_tlast,
+        AXIS_CC_TUSER   => axis_cc_tuser,
+        AXIS_CC_TKEEP   => axis_cc_tkeep,
+--         //----------------------------------------------------------------------------------------------------------------------
+--         // Configuration Interface
+--         // cfg_fc_sel[2:0] = 101b, cfg_fc_ph[7:0], cfg_fc_pd[11:0] cfg_fc_nph[7:0]
+        XIP_CFG_FC_SEL  => xip_cfg_fc_sel_sig,
+        XIP_CFG_FC_PH   => xip_cfg_fc_ph_sig,
+        XIP_CFG_FC_PD   => xip_cfg_fc_pd_sig,
+        XIP_CFG_FC_NP   => xip_cfg_fc_np_sig,
+
+        psl_kill_link  => open,
+        psl_build_ver   => psl_build_ver,
+        afu_clk         => psl_clk,            -- TBD AM.
+
+        PSL_RST         => psl_reset_sig,
+        PSL_CLK         => psl_clk,
+        PCIHIP_PSL_RST  => pcihip0_psl_rst,
+        PCIHIP_PSL_CLK  => pcihip0_psl_clk
+
+    );
+
+cfg_dsn_sig <= x"00000001" & x"01" & x"000A35";
+
+efes32   <= x"00000000";
+--efes1024 <= x"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+one1   <= '1';
+two2   <= one1 & one1;
+
+sys_clk_p   <= pcie_clkp;
+sys_clk_n   <= pcie_clkn;
+sys_rst_n   <= pcie_rst_n;
+
+pcie_txn(15 downto 0)    <= pci_exp_txn(15 downto 0);
+pcie_txp(15 downto 0)    <= pci_exp_txp(15 downto 0);
+pci_exp_rxn(15 downto 0) <= pcie_rxn(15 downto 0);
+pci_exp_rxp(15 downto 0) <= pcie_rxp(15 downto 0);
+--pci0_o_txn_out0 <= pci_exp_txn(0);
+--pci0_o_txp_out0 <= pci_exp_txp(0);
+--pci_exp_rxn(0) <= pci0_i_rxp_in0;
+--pci_exp_rxp(0) <= pci0_i_rxn_in0;
+--pci0_o_txn_out1 <= pci_exp_txn(1);
+--pci0_o_txp_out1 <= pci_exp_txp(1);
+--pci_exp_rxn(1) <= pci0_i_rxp_in1;
+--pci_exp_rxp(1) <= pci0_i_rxn_in1;
+--pci0_o_txn_out2 <= pci_exp_txn(2);
+--pci0_o_txp_out2 <= pci_exp_txp(2);
+--pci_exp_rxn(2) <= pci0_i_rxp_in2;
+--pci_exp_rxp(2) <= pci0_i_rxn_in2;
+--pci0_o_txn_out3 <= pci_exp_txn(3);
+--pci0_o_txp_out3 <= pci_exp_txp(3);
+--pci_exp_rxn(3) <= pci0_i_rxp_in3;
+--pci_exp_rxp(3) <= pci0_i_rxn_in3;
+--pci0_o_txn_out4 <= pci_exp_txn(4);
+--pci0_o_txp_out4 <= pci_exp_txp(4);
+--pci_exp_rxn(4) <= pci0_i_rxp_in4;
+--pci_exp_rxp(4) <= pci0_i_rxn_in4;
+--pci0_o_txn_out5 <= pci_exp_txn(5);
+--pci0_o_txp_out5 <= pci_exp_txp(5);
+--pci_exp_rxn(5) <= pci0_i_rxp_in5;
+--pci_exp_rxp(5) <= pci0_i_rxn_in5;
+--pci0_o_txn_out6 <= pci_exp_txn(6);
+--pci0_o_txp_out6 <= pci_exp_txp(6);
+--pci_exp_rxn(6) <= pci0_i_rxp_in6;
+--pci_exp_rxp(6) <= pci0_i_rxn_in6;
+--pci0_o_txn_out7 <= pci_exp_txn(7);
+--pci0_o_txp_out7 <= pci_exp_txp(7);
+--pci_exp_rxn(7) <= pci0_i_rxp_in7;
+--pci_exp_rxp(7) <= pci0_i_rxn_in7;
+--
+--pci0_o_txn_out8 <= pci_exp_txn(8);
+--pci0_o_txp_out8 <= pci_exp_txp(8);
+--pci_exp_rxn(8) <= pci0_i_rxp_in8;
+--pci_exp_rxp(8) <= pci0_i_rxn_in8;
+--pci0_o_txn_out9 <= pci_exp_txn(9);
+--pci0_o_txp_out9 <= pci_exp_txp(9);
+--pci_exp_rxn(9) <= pci0_i_rxp_in9;
+--pci_exp_rxp(9) <= pci0_i_rxn_in9;
+--pci0_o_txn_out10 <= pci_exp_txn(10);
+--pci0_o_txp_out10 <= pci_exp_txp(10);
+--pci_exp_rxn(10) <= pci0_i_rxp_in10;
+--pci_exp_rxp(10) <= pci0_i_rxn_in10;
+--pci0_o_txn_out11 <= pci_exp_txn(11);
+--pci0_o_txp_out11 <= pci_exp_txp(11);
+--pci_exp_rxn(11) <= pci0_i_rxp_in11;
+--pci_exp_rxp(11) <= pci0_i_rxn_in11;
+--pci0_o_txn_out12 <= pci_exp_txn(12);
+--pci0_o_txp_out12 <= pci_exp_txp(12);
+--pci_exp_rxn(12) <= pci0_i_rxp_in12;
+--pci_exp_rxp(12) <= pci0_i_rxn_in12;
+--pci0_o_txn_out13 <= pci_exp_txn(13);
+--pci0_o_txp_out13 <= pci_exp_txp(13);
+--pci_exp_rxn(13) <= pci0_i_rxp_in13;
+--pci_exp_rxp(13) <= pci0_i_rxn_in13;
+--pci0_o_txn_out14 <= pci_exp_txn(14);
+--pci0_o_txp_out14 <= pci_exp_txp(14);
+--pci_exp_rxn(14) <= pci0_i_rxp_in14;
+--pci_exp_rxp(14) <= pci0_i_rxn_in14;
+--pci0_o_txn_out15 <= pci_exp_txn(15);
+--pci0_o_txp_out15 <= pci_exp_txp(15);
+--pci_exp_rxn(15) <= pci0_i_rxp_in15;
+--pci_exp_rxp(15) <= pci0_i_rxn_in15;
+
+pci_user_reset <= pcihip0_psl_rst;
+pci_clock_125MHz <= psl_clk_div2;
+
+
+pcihip0:      pcie4_uscale_plus_0
+PORT MAP (
+    pci_exp_txn =>  pci_exp_txn ,   -- out STD_LOGIC_VECTOR ( 15 downto 0 );
+    pci_exp_txp =>  pci_exp_txp ,   -- out STD_LOGIC_VECTOR ( 15 downto 0 );
+    pci_exp_rxn =>  pci_exp_rxn ,   -- in STD_LOGIC_VECTOR ( 15 downto 0 );
+    pci_exp_rxp =>  pci_exp_rxp ,   -- in STD_LOGIC_VECTOR ( 15 downto 0 );
+
+    user_clk  => pcihip0_psl_clk,     -- out STD_LOGIC;
+    user_reset  => pcihip0_psl_rst,     -- out STD_LOGIC;
+    user_lnk_up => user_lnk_up,      -- out STD_LOGIC;
+
+    s_axis_rq_tdata => axis_rq_tdata,     -- in  STD_LOGIC_VECTOR ( 511 downto 0 );
+    s_axis_rq_tkeep => axis_rq_tkeep,     -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+    s_axis_rq_tlast => axis_rq_tlast,     -- in  STD_LOGIC;
+    s_axis_rq_tready => axis_rq_tready,   -- out STD_LOGIC_VECTOR ( 3 downto 0 );
+    s_axis_rq_tuser => axis_rq_tuser,     -- in  STD_LOGIC_VECTOR ( 136 downto 0 );
+    s_axis_rq_tvalid => axis_rq_tvalid,   -- in  STD_LOGIC;
+    m_axis_rc_tdata => axis_rc_tdata,     -- out STD_LOGIC_VECTOR ( 511 downto 0 );
+    m_axis_rc_tkeep => open,      -- out STD_LOGIC_VECTOR ( 15 downto 0 );
+    m_axis_rc_tlast => open,      -- out STD_LOGIC;
+    m_axis_rc_tready(0) => axis_rc_tready,  -- axis_rc_tready,    -- in  STD_LOGIC_VECTOR ( 21 downto 0 );
+    m_axis_rc_tuser => axis_rc_tuser,     -- out STD_LOGIC_VECTOR ( 160 downto 0 );
+    m_axis_rc_tvalid => axis_rc_tvalid,   -- out STD_LOGIC;
+    m_axis_cq_tdata => axis_cq_tdata,     -- out STD_LOGIC_VECTOR ( 511 downto 0 );
+    m_axis_cq_tkeep => open,      -- out STD_LOGIC_VECTOR ( 15 downto 0 );
+    m_axis_cq_tlast => open,      -- out STD_LOGIC;
+    m_axis_cq_tready(0) => axis_cq_tready,  -- axis_cq_tready,    -- in  STD_LOGIC_VECTOR ( 21 downto 0 );
+    m_axis_cq_tuser => axis_cq_tuser,     -- out STD_LOGIC_VECTOR ( 182 downto 0 );
+    m_axis_cq_tvalid => axis_cq_tvalid,    -- out STD_LOGIC;
+    s_axis_cc_tdata => axis_cc_tdata,     -- in  STD_LOGIC_VECTOR ( 511 downto 0 );
+    s_axis_cc_tkeep => axis_cc_tkeep,     -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+    s_axis_cc_tlast => axis_cc_tlast,     -- in  STD_LOGIC;
+    s_axis_cc_tready => axis_cc_tready,    -- out STD_LOGIC_VECTOR ( 3 downto 0 );
+    s_axis_cc_tuser => axis_cc_tuser,     -- in  STD_LOGIC_VECTOR ( 80 downto 0 );
+    s_axis_cc_tvalid => axis_cc_tvalid,    -- in  STD_LOGIC;
+
+    pcie_rq_seq_num0 => open,      -- out STD_LOGIC_VECTOR ( 5 downto 0 );
+    pcie_rq_seq_num_vld0 => open,     -- out STD_LOGIC;
+    pcie_rq_seq_num1 => open,      -- out STD_LOGIC_VECTOR ( 5 downto 0 );
+    pcie_rq_seq_num_vld1 => open,     -- out STD_LOGIC;
+    pcie_rq_tag0 => open,      -- out STD_LOGIC_VECTOR ( 7 downto 0 );
+    pcie_rq_tag1 => open,      -- out STD_LOGIC_VECTOR ( 7 downto 0 );
+    pcie_rq_tag_av => open,      -- out STD_LOGIC_VECTOR ( 3 downto 0 );
+    pcie_rq_tag_vld0 => open,      -- out STD_LOGIC;
+    pcie_rq_tag_vld1 => open,      -- out STD_LOGIC;
+    pcie_tfc_nph_av => open,      -- out STD_LOGIC_VECTOR ( 3 downto 0 );
+    pcie_tfc_npd_av => open,      -- out STD_LOGIC_VECTOR ( 3 downto 0 );
+-- Jan 27, 2017    pcie_cq_np_req => (others => '0'),    -- in  STD_LOGIC_VECTOR ( 1 downto 0 );
+    pcie_cq_np_req => two2,    -- in  STD_LOGIC_VECTOR ( 1 downto 0 );     -- Jan 27, 2017
+    pcie_cq_np_req_count => open,     -- out STD_LOGIC_VECTOR ( 5 downto 0 );
+
+    cfg_phy_link_down => open,     -- out STD_LOGIC;
+    cfg_phy_link_status => open,     -- out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_negotiated_width => open,     -- out STD_LOGIC_VECTOR ( 2 downto 0 );
+    cfg_current_speed => open,     -- out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_max_payload => open,      -- out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_max_read_req => open,      -- out STD_LOGIC_VECTOR ( 2 downto 0 );
+    cfg_function_status => open,     -- out STD_LOGIC_VECTOR ( 15 downto 0 );
+    cfg_function_power_state => open,     -- out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_vf_status => open,      -- out STD_LOGIC_VECTOR ( 503 downto 0 );
+    cfg_vf_power_state => open,     -- out STD_LOGIC_VECTOR ( 755 downto 0 );
+    cfg_link_power_state => open,     -- out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_mgmt_addr => efes32(9 downto 0),--(others => '0'),     -- in  STD_LOGIC_VECTOR ( 9 downto 0 );
+    cfg_mgmt_function_number => efes32(7 downto 0),--(others => '0'),   -- in  STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_mgmt_write =>  '0',      -- in  STD_LOGIC;
+    cfg_mgmt_write_data => efes32,    --(others => '0'),    -- in  STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_mgmt_byte_enable => efes32(3 downto 0),    -- (others => '0'),    -- in  STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_mgmt_read => '0',      -- in  STD_LOGIC;
+    cfg_mgmt_read_data => open,     -- out STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_mgmt_read_write_done => open,     -- out STD_LOGIC;
+    cfg_mgmt_debug_access => '0',     -- in  STD_LOGIC;
+    cfg_err_cor_out => open,      -- out STD_LOGIC;
+    cfg_err_nonfatal_out => open,     -- out STD_LOGIC;
+    cfg_err_fatal_out => open,     -- out STD_LOGIC;
+    cfg_local_error_valid => open,     -- out STD_LOGIC;
+--     cfg_ltr_enable => open,     -- out STD_LOGIC;
+    cfg_local_error_out => open,     -- out STD_LOGIC_VECTOR ( 4 downto 0 );
+    cfg_ltssm_state => open,      -- out STD_LOGIC_VECTOR ( 5 downto 0 );
+    cfg_rx_pm_state => open,      -- out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_tx_pm_state => open,      -- out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_rcb_status => open,       -- out STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_obff_enable => open,       -- out STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_pl_status_change => open,      -- out STD_LOGIC;
+    cfg_tph_requester_enable => open,     -- out STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_tph_st_mode => open,       -- out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_vf_tph_requester_enable => open,     -- out STD_LOGIC_VECTOR ( 251 downto 0 );
+    cfg_vf_tph_st_mode => open,      -- out STD_LOGIC_VECTOR ( 755 downto 0 );
+    cfg_msg_received => open,      -- out STD_LOGIC;
+    cfg_msg_received_data => open,      -- out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_msg_received_type => open,      -- out STD_LOGIC_VECTOR ( 4 downto 0 );
+    cfg_msg_transmit => '0',       -- in  STD_LOGIC;
+    cfg_msg_transmit_type => efes32(2 downto 0),    -- (others => '0'),    -- in  STD_LOGIC_VECTOR ( 2 downto 0 );
+    cfg_msg_transmit_data => efes32, --(others => '0'),    -- in  STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_msg_transmit_done => open,      -- out STD_LOGIC;
+    cfg_fc_ph => xip_cfg_fc_ph_sig,      -- out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_fc_pd => xip_cfg_fc_pd_sig,      -- out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_fc_nph => xip_cfg_fc_np_sig,      -- out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_fc_npd => open,       -- out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_fc_cplh => open,       -- out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_fc_cpld => open,       -- out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_fc_sel => xip_cfg_fc_sel_sig,     -- in  STD_LOGIC_VECTOR ( 2 downto 0 );
+--     cfg_dsn => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 63 downto 0 );
+    cfg_dsn => cfg_dsn_sig,       -- in  STD_LOGIC_VECTOR ( 63 downto 0 );
+    cfg_bus_number => open,       -- out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_power_state_change_ack => '0',     -- in  STD_LOGIC;
+    cfg_power_state_change_interrupt => open,    -- out STD_LOGIC;
+    cfg_err_cor_in => '0',       -- in  STD_LOGIC;
+    cfg_err_uncor_in => '0',       -- in  STD_LOGIC;
+    cfg_flr_in_process => open,      -- out STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_flr_done => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_vf_flr_in_process => open,      -- out STD_LOGIC_VECTOR ( 251 downto 0 );
+    cfg_vf_flr_func_num => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_vf_flr_done => (others => '0'),       -- in  STD_LOGIC_VECTOR ( 0 to 0 );
+--     cfg_link_training_enable => '0',       -- in  STD_LOGIC;
+    cfg_link_training_enable => '1',       -- in  STD_LOGIC;
+    cfg_ext_read_received => cfg_ext_read_received,     -- out STD_LOGIC;
+    cfg_ext_write_received => cfg_ext_write_received,   -- out STD_LOGIC;
+    cfg_ext_register_number => cfg_ext_register_number, -- out STD_LOGIC_VECTOR ( 9 downto 0 );
+    cfg_ext_function_number => cfg_ext_function_number,       -- out STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_ext_write_data => cfg_ext_write_data,      -- out STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_ext_write_byte_enable => cfg_ext_write_byte_enable,     -- out STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_ext_read_data => cfg_ext_read_data,      -- in  STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_ext_read_data_valid => cfg_ext_read_data_valid,  -- in  STD_LOGIC;
+    cfg_interrupt_int => efes32(3 downto 0),      -- in  STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_interrupt_pending => efes32(3 downto 0),    -- in  STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_interrupt_sent => open,        -- out STD_LOGIC;
+
+
+    cfg_interrupt_msi_enable => open,       -- : out STD_LOGIC_VECTOR ( 3 downto 0 );
+    cfg_interrupt_msi_mmenable => open,       -- : out STD_LOGIC_VECTOR ( 11 downto 0 );
+    cfg_interrupt_msi_mask_update => open,       -- : out STD_LOGIC;
+    cfg_interrupt_msi_data => open,         -- : out STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_interrupt_msi_select => (others => '0'),        -- : in STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_interrupt_msi_int => (others => '0'),        -- : in STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_interrupt_msi_pending_status => (others => '0'),       -- : in STD_LOGIC_VECTOR ( 31 downto 0 );
+    cfg_interrupt_msi_pending_status_data_enable => '0',     -- : in STD_LOGIC;
+    cfg_interrupt_msi_pending_status_function_num => (others => '0'),   -- : in STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_interrupt_msi_sent => open,         -- : out STD_LOGIC;
+    cfg_interrupt_msi_fail => open,         -- : out STD_LOGIC;
+    cfg_interrupt_msi_attr => (others => '0'),        -- : in STD_LOGIC_VECTOR ( 2 downto 0 );
+    cfg_interrupt_msi_tph_present => '0',       -- : in STD_LOGIC;
+    cfg_interrupt_msi_tph_type => (others => '0'),        -- : in STD_LOGIC_VECTOR ( 1 downto 0 );
+    cfg_interrupt_msi_tph_st_tag => (others => '0'),       -- : in STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_interrupt_msi_function_number => (others => '0'),       -- : in STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_pm_aspm_l1_entry_reject => '0',       -- : in STD_LOGIC;
+-- AM. Apr 8    cfg_pm_aspm_tx_l0s_entry_disable => '0',       -- : in STD_LOGIC;
+    cfg_pm_aspm_tx_l0s_entry_disable => '1',       -- : in STD_LOGIC;
+    cfg_hot_reset_out => open,         -- : out STD_LOGIC;
+--     cfg_config_space_enable => '0',        -- : in STD_LOGIC;
+    cfg_config_space_enable => '1',        -- : in STD_LOGIC;
+    cfg_req_pm_transition_l23_ready => '0',       -- : in STD_LOGIC;
+    cfg_hot_reset_in => '0',         -- : in STD_LOGIC;
+    cfg_ds_port_number => (others => '0'),         -- : in STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_ds_bus_number => (others => '0'),         -- : in STD_LOGIC_VECTOR ( 7 downto 0 );
+    cfg_ds_device_number => (others => '0'),        -- : in STD_LOGIC_VECTOR ( 4 downto 0 );
+
+----    cfg_pm_aspm_l1_entry_reject => '0',       -- in  STD_LOGIC;
+----    cfg_pm_aspm_tx_l0s_entry_disable => '0',      -- in  STD_LOGIC;
+----    cfg_hot_reset_out => open,        -- out STD_LOGIC;
+----    cfg_config_space_enable => '0',       -- in  STD_LOGIC;
+----    cfg_req_pm_transition_l23_ready => '0',      -- in  STD_LOGIC;
+----    cfg_hot_reset_in => '0',        -- in  STD_LOGIC;
+----    cfg_ds_port_number => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 7 downto 0 );
+----    cfg_ds_bus_number => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 7 downto 0 );
+----    cfg_ds_device_number => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 4 downto 0 );
+----    cfg_ds_function_number => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 2 downto 0 );
+--    cfg_subsys_vend_id => (X"1014"),      -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+--    cfg_dev_id_pf0 => (X"0477"),       -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+----    cfg_dev_id_pf1 => (others => '0'),       -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+----    cfg_dev_id_pf2 => (others => '0'),       -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+----    cfg_dev_id_pf3 => (others => '0'),       -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+--    cfg_vend_id => (X"1014"),       -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+--    cfg_rev_id_pf0 => (X"02"),       -- in  STD_LOGIC_VECTOR ( 7 downto 0 );
+----    cfg_rev_id_pf1 => (others => '0'),       -- in  STD_LOGIC_VECTOR ( 7 downto 0 );
+----    cfg_rev_id_pf2 => (others => '0'),       -- in  STD_LOGIC_VECTOR ( 7 downto 0 );
+----    cfg_rev_id_pf3 => (others => '0'),       -- in  STD_LOGIC_VECTOR ( 7 downto 0 );
+--    cfg_subsys_id_pf0 => (X"060f"),      -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+----    cfg_subsys_id_pf1 => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+----    cfg_subsys_id_pf2 => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+----    cfg_subsys_id_pf3 => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+--
+--     sys_clk => sys_clk_p,        -- in  STD_LOGIC;
+    sys_clk => sys_clk,         -- in  STD_LOGIC;
+    sys_clk_gt => sys_clk_gt,        -- in  STD_LOGIC;
+--     sys_reset =>  PCIE_PERST_LS   -- sys_rst_n  -- in  STD_LOGIC
+    sys_reset =>  sys_rst_n_c,  -- in  STD_LOGIC
+
+    phy_rdy_out => open
+
+    --int_qpll0lock_out  => open,
+    --int_qpll0outrefclk_out  => open,
+    --int_qpll0outclk_out  => open,
+    --int_qpll1lock_out  => open,
+    --int_qpll1outrefclk_out  => open,
+    --int_qpll1outclk_out => open
+
+  );
+
+-- CAPI board infrastructure
+capi_bis : capi_board_infrastructure
+  PORT map (
+    cfg_ext_read_received       => cfg_ext_read_received,
+    cfg_ext_write_received      => cfg_ext_write_received,
+    cfg_ext_register_number     => cfg_ext_register_number,
+    cfg_ext_function_number     => cfg_ext_function_number,
+    cfg_ext_write_data          => cfg_ext_write_data,
+    cfg_ext_write_byte_enable   => cfg_ext_write_byte_enable,
+    cfg_ext_read_data           => cfg_ext_read_data,
+    cfg_ext_read_data_valid     => cfg_ext_read_data_valid,
+
+   -- spi_miso_secondary          => spi_miso_secondary,
+   -- spi_mosi_secondary          => spi_mosi_secondary,
+   -- spi_cen_secondary           => spi_cen_secondary,
+
+    pci_pi_nperst0              => sys_rst_n_c,
+    pcihip0_psl_clk             => pcihip0_psl_clk,
+    icap_clk                    => icap_clk,
+    cpld_usergolden             => gold_factory,
+    crc_error                   => crc_error
+    );
+
+-- Xilinx component which is required to generate correct clocks towards PCIHIP
+refclk_ibuf : IBUFDS_GTE4
+-- generic map (
+-- REFCLK_EN_TX_PATH  => '0',  -- Refer to Transceiver User Guide
+-- REFCLK_HROW_CK_SEL  => "00",  -- Refer to Transceiver User Guide
+-- REFCLK_ICNTL_RX  => "00"  -- Refer to Transceiver User Guide
+-- )
+port map (
+    O   => sys_clk_gt,   -- 1-bit output: Refer to Transceiver User Guide
+    ODIV2  => sys_clk,   -- 1-bit output: Refer to Transceiver User Guide
+    CEB  => '0',   -- 1'b0,   -- 1-bit input: Refer to Transceiver User Guide
+    I   => sys_clk_p,   -- 1-bit input: Refer to Transceiver User Guide
+    IB   => sys_clk_n   -- 1-bit input: Refer to Transceiver User Guide
+);
+-- End of IBUFDS_GTE4_inst instantiation
+
+
+IBUF_inst : IBUF
+port map (
+O => sys_rst_n_c,  -- 1-bit output: Buffer output
+I => sys_rst_n   -- 1-bit input: Buffer input
+);
+-- End of IBUF_inst instantiation
+
+
+--        gate clock_lite until clocks are stable after link up
+--        avoid glitches to sem core to prevent false errors or worse
+--        also used to clock multiboot logic so keep enabled when link goes down
+-- clock_lite_ce <= clock_gen_locked and not(user_reset);
+dff_icap_clk_ce: capi_rise_dff PORT MAP (
+     dout => icap_clk_ce,
+     din => icap_clk_ce_d,
+     clk   => pcihip0_psl_clk
+);
+
+icap_clk_ce_d <= icap_clk_ce or (clk_wiz_2_locked and not(pcihip0_psl_rst));
+-- MMCM to generate PSL clock (100...250MHz)
+pll0:         uscale_plus_clk_wiz
+PORT MAP  (
+    clk_in1  => pcihip0_psl_clk, -- Driven by PCIHIP
+    clk_out1  => psl_clk,   -- Goes to PSL logic
+    clk_out2    => psl_clk_div2, -- 125MHz out to psl_accel if required (went to PSL logic)
+    clk_out3  => icap_clk,     -- Goes to SEM, multiboot
+    clk_out3_ce => icap_clk_ce,     -- gate off while unstable to prevent SEM errors
+    reset   => '0', -- Driven by PCIHIP
+    locked   => clk_wiz_2_locked
+  );
+
+
+
+
+--Component capi_fpga_reset
+capi_fpga_reset:CAPI_FPGA_RESET_GEN
+ PORT MAP (
+   PLL_LOCKED  => clk_wiz_2_locked,
+   CLK   => psl_clk,
+   RESET  => psl_reset_sig
+   );
+
+-- Component capi_stp_counter
+csc:          CAPI_STP_COUNTER
+ PORT MAP (
+   CLK   => psl_clk,
+   RESET  => psl_reset_sig,
+   STP_COUNTER_1sec => stp_counter_1sec_sig,
+   STP_COUNTER_MSB => stp_counter_msb_sig
+   );
+
+
+------ sys_clk_p_out: CAPI_STP_COUNTER
+------  PORT MAP (
+------    CLK   => sys_clk,
+------    RESET  => pcihip0_psl_rst,
+------    STP_COUNTER_1sec => sys_clk_counter_1sec_sig,
+------    STP_COUNTER_MSB => open
+------    );
+
+user_clock:   CAPI_STP_COUNTER
+ PORT MAP (
+   CLK   => pcihip0_psl_clk,
+   RESET  => pcihip0_psl_rst,
+   STP_COUNTER_1sec => user_clock_sig,
+   STP_COUNTER_MSB => open
+   );
+
+
+END capi_bsp;

--- a/U200/src/capi_flash_spi_mt25qt.vhdl
+++ b/U200/src/capi_flash_spi_mt25qt.vhdl
@@ -1,0 +1,1525 @@
+-- *!***************************************************************************
+-- *! Copyright 2014-2018 International Business Machines
+-- *!
+-- *! Licensed under the Apache License, Version 2.0 (the "License");
+-- *! you may not use this file except in compliance with the License.
+-- *! You may obtain a copy of the License at
+-- *!
+-- *!     http://www.apache.org/licenses/LICENSE-2.0
+-- *!
+-- *! Unless required by applicable law or agreed to in writing, software
+-- *! distributed under the License is distributed on an "AS IS" BASIS,
+-- *! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- *! See the License for the specific language governing permissions and
+-- *! limitations under the License.
+-- *!
+-- *!***************************************************************************
+
+library ieee, UNISIM;
+use UNISIM.vcomponents.all;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.std_logic_misc.all;
+
+ENTITY capi_flash_spi_mt25qt IS
+  PORT(psl_clk: in std_logic;
+
+       -- --------------- --
+       spi_clk: out std_logic;
+       spi_cen: out std_logic;
+       spi_miso : in std_logic;
+       spi_mosi : out std_logic;
+
+       -- -------------- --
+       f_program_req: in std_logic;                                         -- Level --
+       f_num_blocks: in std_logic_vector(0 to 15);                           -- 128KB Block Size --
+       f_start_blk: in std_logic_vector(0 to 9);
+       f_program_data: in std_logic_vector(0 to 31);
+       f_program_data_val: in std_logic;
+       f_program_data_ack: out std_logic;
+       f_ready: out std_logic;
+       f_done: out std_logic;
+       f_stat_erase: out std_logic;
+       f_stat_program: out std_logic;
+       f_stat_read: out std_logic;
+       f_remainder: out std_logic_vector(0 to 9);
+
+       -- Read Interface --
+       f_read_req: in std_logic;
+       f_num_words_m1: in std_logic_vector(0 to 15);                         -- N-1 words --
+       f_read_start_addr: in std_logic_vector(0 to 31);
+       f_read_data: out std_logic_vector(0 to 31);
+       f_read_data_val: out std_logic;
+       f_read_data_ack: in std_logic);
+
+END capi_flash_spi_mt25qt;
+
+ARCHITECTURE capi_flash_spi_mt25qt OF capi_flash_spi_mt25qt IS
+
+Component capi_en_rise_vdff
+  GENERIC ( width : positive );
+  PORT (clk   : in std_logic;
+        en    : in std_logic;
+        dout  : out std_logic_vector(0 to width-1);
+        din   : in std_logic_vector(0 to width-1));
+End Component capi_en_rise_vdff;
+
+Component capi_rise_dff
+  PORT (clk   : in std_logic;
+        dout  : out std_logic;
+        din   : in std_logic);
+End Component capi_rise_dff;
+
+Component capi_rise_dff_init1
+  PORT (clk   : in std_logic;
+        dout  : out std_logic;
+        din   : in std_logic);
+End Component capi_rise_dff_init1;
+
+Component capi_en_rise_dff
+  PORT (clk   : in std_logic;
+        en    : in std_logic;
+        dout  : out std_logic;
+        din   : in std_logic);
+End Component capi_en_rise_dff;
+
+Component capi_rise_vdff
+  GENERIC ( width : positive );
+  PORT (clk   : in std_logic;
+        dout  : out std_logic_vector(0 to width-1);
+        din   : in std_logic_vector(0 to width-1));
+End Component capi_rise_vdff;
+
+function gate_and (gate : std_logic; din : std_logic_vector) return std_logic_vector is
+begin
+  if (gate = '1') then
+    return din;
+  else
+    return (0 to din'length-1 => '0');
+  end if;
+end gate_and;
+
+Signal ONE_v17bit: std_logic_vector(0 to 16);  -- v17bit
+Signal ONE_v9bit: std_logic_vector(0 to 8);  -- v9bit
+Signal Z_v10bit: std_logic_vector(0 to 9);  -- v10bit
+Signal Z_v17bit: std_logic_vector(0 to 16);  -- v17bit
+Signal Z_v32bit: std_logic_vector(0 to 31);  -- v32bit
+Signal Z_v9bit: std_logic_vector(0 to 8);  -- v9bit
+Signal buf_dat: std_logic_vector(0 to 31);  -- v32bit
+Signal buf_full: std_logic;  -- bool
+Signal cnt_en: std_logic;  -- bool
+Signal cycdly_d: std_logic_vector(0 to 15);  -- v6bit
+Signal cycdly_m1: std_logic_vector(0 to 15);  -- v6bit
+Signal cycdly_q: std_logic_vector(0 to 15);  -- v6bit
+Signal datain_hien: std_logic;  -- bool
+Signal datain_loen: std_logic;  -- bool
+Signal dly_done: std_logic;  -- bool
+Signal erase_addr: std_logic_vector(0 to 25);  -- v26bit
+Signal erase_adr_sel: std_logic;  -- bool
+Signal erase_ce: std_logic;  -- bool
+Signal erase_complete: std_logic;  -- bool
+Signal erase_dat_oe: std_logic;  -- bool
+Signal erase_data_out: std_logic_vector(0 to 31);  -- v32bit
+Signal erase_dly: std_logic_vector(0 to 5);  -- v6bit
+Signal erase_oe: std_logic;  -- bool
+Signal erase_sm: std_logic_vector(0 to 4);  -- v5bit
+Signal erase_sm_nxt: std_logic_vector(0 to 4);  -- v5bit
+Signal erase_sm_p1: std_logic_vector(0 to 4);  -- v5bit
+Signal erase_sm_start_dly: std_logic;  -- bool
+Signal erase_we: std_logic;  -- bool
+Signal esm_adv: std_logic;  -- bool
+Signal esm_blkadr_d: std_logic_vector(0 to 15);  -- v16bit
+Signal esm_blkadr_p1: std_logic_vector(0 to 15);  -- v16bit
+Signal esm_blkadr_q: std_logic_vector(0 to 15);  -- v16bit
+Signal esm_blkcnt_d: std_logic_vector(0 to 15);  -- v16bit
+Signal esm_blkcnt_m1: std_logic_vector(0 to 15);  -- v16bit
+Signal esm_blkcnt_q: std_logic_vector(0 to 15);  -- v16bit
+Signal esm_datain_en: std_logic;  -- bool
+Signal esm_done: std_logic;  -- bool
+Signal esm_no_dly_sel: std_logic;  -- bool
+Signal esm_p1: std_logic;  -- bool
+Signal esm_redo_rd: std_logic;  -- bool
+Signal esm_rst: std_logic;  -- bool
+Signal esm_sel_CEH_dly: std_logic;  -- bool
+Signal esm_sel_FTD_dly: std_logic;  -- bool
+Signal esm_sel_OEH_dly: std_logic;  -- bool
+Signal esm_sel_OEL_dly: std_logic;  -- bool
+Signal esm_sel_WEH_dly: std_logic;  -- bool
+Signal esm_sel_WEL_dly: std_logic;  -- bool
+Signal esm_sel_clrstat: std_logic;  -- bool
+Signal esm_sel_erase: std_logic;  -- bool
+Signal esm_sel_execute: std_logic;  -- bool
+Signal esm_sel_unlock: std_logic;  -- bool
+Signal esm_sel_zero: std_logic;  -- bool
+Signal esm_update_blkadr: std_logic;  -- bool
+Signal esm_update_blkcnt: std_logic;  -- bool
+Signal faddr: std_logic_vector(0 to 25);  -- v26bit
+Signal faddr_be: std_logic_vector(0 to 25);  -- v26bit
+Signal fcen: std_logic_vector(0 to 1);  -- v2bit
+Signal fcen_0: std_logic;  -- bool
+Signal fcen_1: std_logic;  -- bool
+Signal fdatain: std_logic_vector(0 to 31);  -- v32bit
+Signal fdatain_hi: std_logic_vector(0 to 15);  -- v16bit
+Signal fdatain_lo: std_logic_vector(0 to 15);  -- v16bit
+Signal fdataout: std_logic_vector(0 to 15);  -- v16bit
+Signal fdataout_be: std_logic_vector(0 to 31);  -- v32bit
+Signal fdataout_be_d: std_logic_vector(0 to 15);  -- v16bit
+Signal fdatoe: std_logic;  -- bool
+Signal fintf_oe: std_logic;  -- bool
+Signal flash_busy: std_logic;  -- bool
+Signal flash_error: std_logic;  -- bool
+Signal foen: std_logic;  -- bool
+Signal frstn: std_logic;  -- bool
+Signal fwen: std_logic;  -- bool
+Signal init_buf_off: std_logic;  -- bool
+Signal init_cnt_adr: std_logic;  -- bool
+Signal main_dly: std_logic_vector(0 to 5);  -- v6bit
+Signal main_sm_nxt_0: std_logic;  -- bool
+Signal main_sm_nxt_1: std_logic;  -- bool
+Signal main_sm_nxt_2: std_logic;  -- bool
+Signal main_sm_nxt_3: std_logic;  -- bool
+Signal main_sm_nxt_4: std_logic;  -- bool
+Signal main_sm_nxt_5: std_logic;  -- bool
+Signal main_sm_nxt_6: std_logic;  -- bool
+Signal main_sm_nxt_7: std_logic;  -- bool
+Signal main_sm_start_dly: std_logic;  -- bool
+Signal msm_no_dly_sel: std_logic;  -- bool
+Signal msm_rstp_dly_sel: std_logic;  -- bool
+Signal msm_rstr_dly_sel: std_logic;  -- bool
+Signal new_dly: std_logic_vector(0 to 15);  -- v6bit
+Signal num_buffers: std_logic_vector(0 to 16);  -- v17bit
+Signal pflreqn: std_logic;  -- bool
+Signal pgm_addr: std_logic_vector(0 to 25);  -- v26bit
+Signal pgm_adr_sel: std_logic;  -- bool
+Signal pgm_ce: std_logic;  -- bool
+Signal pgm_complete: std_logic;  -- bool
+Signal pgm_dat_oe: std_logic;  -- bool
+Signal pgm_data_out: std_logic_vector(0 to 31);  -- v32bit
+Signal pgm_dly: std_logic_vector(0 to 5);  -- v6bit
+Signal pgm_oe: std_logic;  -- bool
+Signal pgm_rd_req: std_logic;  -- bool
+Signal pgm_remainder: std_logic_vector(0 to 9);  -- v10bit
+Signal pgm_sm: std_logic_vector(0 to 4);  -- v5bit
+Signal pgm_sm_nxt: std_logic_vector(0 to 4);  -- v5bit
+Signal pgm_sm_p1: std_logic_vector(0 to 4);  -- v5bit
+Signal pgm_sm_start_dly: std_logic;  -- bool
+Signal pgm_we: std_logic;  -- bool
+Signal program_flash: std_logic;  -- bool
+Signal psm_adv: std_logic;  -- bool
+Signal psm_bufadr_d: std_logic_vector(0 to 16);  -- v17bit
+Signal psm_bufadr_p1: std_logic_vector(0 to 16);  -- v17bit
+Signal psm_bufadr_q: std_logic_vector(0 to 16);  -- v17bit
+Signal psm_bufcnt_d: std_logic_vector(0 to 16);  -- v17bit
+Signal psm_bufcnt_m1: std_logic_vector(0 to 16);  -- v17bit
+Signal psm_bufcnt_q: std_logic_vector(0 to 16);  -- v17bit
+Signal psm_bufoff_d: std_logic_vector(0 to 8);  -- v9bit
+Signal psm_bufoff_p1: std_logic_vector(0 to 8);  -- v9bit
+Signal psm_bufoff_q: std_logic_vector(0 to 8);  -- v9bit
+Signal psm_datain_en: std_logic;  -- bool
+Signal psm_done: std_logic;  -- bool
+Signal psm_more_bufs: std_logic;  -- bool
+Signal psm_no_dly_sel: std_logic;  -- bool
+Signal psm_p1: std_logic;  -- bool
+Signal psm_pgm_nxt_buf: std_logic;  -- bool
+Signal psm_redo_bufavail_rd: std_logic;  -- bool
+Signal psm_redo_bufdone_rd: std_logic;  -- bool
+Signal psm_sel_CEH_dly: std_logic;  -- bool
+Signal psm_sel_FTD_dly: std_logic;  -- bool
+Signal psm_sel_OEH_dly: std_logic;  -- bool
+Signal psm_sel_OEL_dly: std_logic;  -- bool
+Signal psm_sel_WEH_dly: std_logic;  -- bool
+Signal psm_sel_WEL_dly: std_logic;  -- bool
+Signal psm_sel_bufcmd: std_logic;  -- bool
+Signal psm_sel_bufdat: std_logic;  -- bool
+Signal psm_sel_clrstat: std_logic;  -- bool
+Signal psm_sel_execute: std_logic;  -- bool
+Signal psm_sel_zero: std_logic;  -- bool
+Signal psm_update_bufadr: std_logic;  -- bool
+Signal psm_update_bufcnt: std_logic;  -- bool
+Signal psm_update_bufoff: std_logic;  -- bool
+Signal psm_update_wrdcnt: std_logic;  -- bool
+Signal psm_wr_nxt_buf_dat: std_logic;  -- bool
+Signal psm_wrcntdec_en_d: std_logic;  -- bool
+Signal psm_wrcntdec_en_q: std_logic;  -- bool
+Signal psm_wrdat_d: std_logic;  -- bool
+Signal psm_wrdat_q: std_logic;  -- bool
+Signal psm_wrdcnt_d: std_logic_vector(0 to 8);  -- v9bit
+Signal psm_wrdcnt_m1: std_logic_vector(0 to 8);  -- v9bit
+Signal psm_wrdcnt_q: std_logic_vector(0 to 8);  -- v9bit
+Signal rd_start_addr: std_logic_vector(0 to 25);  -- v26bit
+Signal read_addr: std_logic_vector(0 to 25);  -- v26bit
+Signal read_adr_sel: std_logic;  -- bool
+Signal read_ce: std_logic;  -- bool
+Signal read_complete: std_logic;  -- bool
+Signal read_dat_oe: std_logic;  -- bool
+Signal read_data_out: std_logic_vector(0 to 31);  -- v32bit
+Signal read_data_val_d: std_logic;  -- bool
+Signal read_dly: std_logic_vector(0 to 5);  -- v6bit
+Signal read_flash: std_logic;  -- bool
+Signal read_oe: std_logic;  -- bool
+Signal read_sm: std_logic_vector(0 to 4);  -- v5bit
+Signal read_sm_nxt: std_logic_vector(0 to 4);  -- v5bit
+Signal read_sm_p1: std_logic_vector(0 to 4);  -- v5bit
+Signal read_sm_start_dly: std_logic;  -- bool
+Signal read_we: std_logic;  -- bool
+Signal rsm_adv: std_logic;  -- bool
+Signal rsm_datain_en: std_logic;  -- bool
+Signal rsm_done: std_logic;  -- bool
+Signal rsm_more_dat: std_logic;  -- bool
+Signal rsm_no_dly_sel: std_logic;  -- bool
+Signal rsm_p1: std_logic;  -- bool
+Signal rsm_rd_nxt_wrd: std_logic;  -- bool
+Signal rsm_rst: std_logic;  -- bool
+Signal rsm_sel_CEH_dly: std_logic;  -- bool
+Signal rsm_sel_FTD_dly: std_logic;  -- bool
+Signal rsm_sel_RCT_dly: std_logic;  -- bool
+Signal rsm_sel_WEH_dly: std_logic;  -- bool
+Signal rsm_sel_WEL_dly: std_logic;  -- bool
+Signal rsm_sel_rdcmd: std_logic;  -- bool
+Signal rsm_update_wrdadr: std_logic;  -- bool
+Signal rsm_update_wrdcnt: std_logic;  -- bool
+Signal rsm_wrdadr_d: std_logic_vector(0 to 25);  -- v26bit
+Signal rsm_wrdadr_p1: std_logic_vector(0 to 25);  -- v26bit
+Signal rsm_wrdadr_q: std_logic_vector(0 to 25);  -- v26bit
+Signal rsm_wrdcnt_d: std_logic_vector(0 to 9);  -- v10bit
+Signal rsm_wrdcnt_m1: std_logic_vector(0 to 9);  -- v10bit
+Signal rsm_wrdcnt_q: std_logic_vector(0 to 9);  -- v10bit
+Signal rst_pulse: std_logic_vector(0 to 5);  -- v6bit
+Signal rst_recov: std_logic_vector(0 to 5);  -- v6bit
+Signal start_buf: std_logic_vector(0 to 16);  -- v17bit
+Signal start_dly: std_logic;  -- bool
+--Signal version: std_logic_vector(0 to 31);  -- int
+Signal f_read_data_valinternal: std_logic;  -- bool
+Signal flash_dataout_d: std_logic_vector(0 to 15);
+Signal flash_datain_d: std_logic_vector(0 to 15);
+Signal flash_addr_d: std_logic_vector(0 to 25);
+Signal flash_intf_oe_d: std_logic_vector(0 to 30);
+Signal flash_dat_oe_d: std_logic_vector(0 to 15);
+Signal flash_wen_d: std_logic;
+Signal flash_oen_d: std_logic;
+Signal flash_cen_d: std_logic_vector(0 to 1);
+Signal flash_rstn_d: std_logic;
+Signal flash_intf_oe_unrep_d: std_logic;
+Signal flash_dat_oe_unrep_d: std_logic;
+Signal spi_in: std_logic_vector(0 to 3);
+Signal spi_cs: std_logic;
+Signal msm_rst: std_logic;
+Signal msm_p1: std_logic;
+Signal msm_to_s0x0F: std_logic;
+Signal msm_to_s0x11: std_logic;
+Signal msm_to_s0x18: std_logic;
+Signal msm_to_s0x31: std_logic;
+Signal msm_to_s0x14: std_logic;
+Signal msm_to_s0x2E: std_logic;
+Signal msm_to_s0x3E: std_logic;
+Signal msm_to_s0x2F: std_logic;
+Signal msm_to_s0x1B: std_logic;
+Signal msm_return: std_logic;
+Signal main_sm_p1: std_logic_vector(0 to 5);
+Signal main_sm_nxt: std_logic_vector(0 to 5);
+Signal main_sm_adv: std_logic;
+Signal main_sm: std_logic_vector(0 to 5);
+Signal msm_return_p1: std_logic;
+Signal msm_return_pgm: std_logic;
+Signal msm_return_read: std_logic;
+Signal msm_returnstate_update: std_logic;
+Signal msm_returnstate: std_logic_vector(0 to 5);
+Signal msm_returnstate_d: std_logic_vector(0 to 5);
+Signal msm_s0x00: std_logic;  -- bool
+Signal msm_s0x01: std_logic;  -- bool
+Signal msm_s0x10: std_logic;  -- bool
+Signal msm_s0x11: std_logic;  -- bool
+Signal msm_s0x12: std_logic;  -- bool
+Signal msm_s0x13: std_logic;  -- bool
+Signal msm_s0x14: std_logic;  -- bool
+Signal msm_s0x15: std_logic;  -- bool
+Signal msm_s0x16: std_logic;  -- bool
+Signal msm_s0x17: std_logic;  -- bool
+Signal msm_s0x18: std_logic;  -- bool
+Signal msm_s0x19: std_logic;  -- bool
+Signal msm_s0x1A: std_logic;  -- bool
+Signal msm_s0x1B: std_logic;  -- bool
+Signal msm_s0x1C: std_logic;  -- bool
+Signal msm_s0x1D: std_logic;  -- bool
+Signal msm_s0x2E: std_logic;  -- bool
+Signal msm_s0x2F: std_logic;  -- bool
+Signal msm_s0x02: std_logic;  -- bool
+Signal msm_s0x03: std_logic;  -- bool
+Signal msm_s0x04: std_logic;  -- bool
+Signal msm_s0x05: std_logic;  -- bool
+Signal msm_s0x0F: std_logic;
+Signal msm_s0x30: std_logic;  -- bool
+Signal msm_s0x31: std_logic;  -- bool
+Signal msm_s0x32: std_logic;  -- bool
+Signal msm_s0x3E: std_logic;  -- bool
+Signal qspi_rst_en: std_logic_vector(0 to 7);
+Signal qspi_rst_mem: std_logic_vector(0 to 7);
+Signal qspi_enter_4B_addr: std_logic_vector(0 to 7);--Command Only
+Signal qspi_enter_quad_mode: std_logic_vector(0 to 7);--Command Only
+Signal qspi_we: std_logic_vector(0 to 7);
+Signal qspi_4B_read: std_logic_vector(0 to 7);--Com-Adr-Data--
+Signal qspi_fstatus_read: std_logic_vector(0 to 7);--Command then Data--
+Signal qspi_fstatus_clear: std_logic_vector(0 to 7);--Command Only
+Signal qspi_4B_page_pgm: std_logic_vector(0 to 7);--Com-Adr-Data--
+Signal qspi_sector_erase: std_logic_vector(0 to 7);--Command then Address
+Signal quad_mode_update: std_logic;
+Signal quad_mode_d: std_logic;
+Signal quad_mode: std_logic;
+Signal fourB_address_mode_update: std_logic;
+Signal fourB_address_mode_d: std_logic;
+Signal fourB_address_mode: std_logic;
+Signal command_sent: std_logic;
+Signal address_sent_update: std_logic;
+Signal address_sent_d: std_logic;
+Signal address_sent: std_logic;
+Signal data_sent_update: std_logic;
+Signal data_sent_d: std_logic;
+Signal data_sent: std_logic;
+Signal start_address_update: std_logic;
+Signal start_address_d: std_logic_vector(0 to 31);
+Signal start_address: std_logic_vector(0 to 31);
+Signal start_sectors_d: std_logic_vector(0 to 15);
+Signal start_sectors: std_logic_vector(0 to 15);
+Signal start_sectors_update: std_logic;
+Signal command_update: std_logic;
+Signal command_d: std_logic_vector(0 to 7);
+Signal command: std_logic_vector(0 to 7);
+Signal read_speed_d: std_logic;
+Signal read_speed_update: std_logic;
+Signal read_speed: std_logic;
+Signal msm_update_blkadr: std_logic;
+Signal msm_update_blkadr_q: std_logic;
+Signal esm_blkadr: std_logic_vector(0 to 31);
+Signal msm_byteadr: std_logic_vector(0 to 31);
+Signal msm_byteadr_p1: std_logic_vector(0 to 23);
+Signal msm_byteadr_d: std_logic_vector(0 to 23);
+Signal msm_update_byteadr: std_logic;
+Signal msm_update_byteadr_q: std_logic;
+Signal msm_byteadr_q: std_logic_vector(0 to 23);
+Signal more2erase: std_logic;
+Signal msm_bytecnt_m1: std_logic_vector(0 to 23);
+Signal msm_bytecnt_d: std_logic_vector(0 to 23);
+Signal msm_update_bytecnt:std_logic;
+Signal msm_bytecnt_q: std_logic_vector(0 to 23);
+Signal msm_bytecnt: std_logic_vector(0 to 23);
+Signal more2pgm: std_logic;
+Signal more2read: std_logic;
+Signal spi_clk_tristate_n: std_logic;
+Signal spi_clk_d: std_logic := '1';
+Signal spi_clk_q: std_logic := '1';
+Signal spi_clk_qq: std_logic := '1';
+Signal spi_clk_int: std_logic := '1';
+Signal spi_cs_d: std_logic;
+Signal fifo_reset: std_logic;
+Signal pgm_fifo_push: std_logic;
+Signal pgm_data_mux_d: std_logic_vector(0 to 1);
+Signal pgm_data_mux_en: std_logic;
+Signal pgm_data_mux_q: std_logic_vector(0 to 1);
+Signal pgm_fifo_wrdata: std_logic_vector(0 to 7);
+Signal pgm_fifo_pull: std_logic;
+Signal pgm_fifo_empty: std_logic;
+Signal pgm_fifo_full: std_logic;
+Signal pgm_fifo_rddata: std_logic_vector(0 to 7);
+Signal pgm_fifo_cnt_d: std_logic_vector(0 to 9);
+Signal pgm_fifo_cnt: std_logic_vector(0 to 9);
+Signal txfifo_has_256B: std_logic;
+Signal rd_fifo_push: std_logic;
+Signal rd_fifo_wrdata: std_logic_vector(0 to 7);
+Signal rd_fifo_pull: std_logic;
+Signal rd_fifo_pull_q: std_logic;
+Signal rd_fifo_empty: std_logic;
+Signal rd_fifo_full: std_logic;
+Signal rd_fifo_rddata: std_logic_vector(0 to 7);
+Signal rd_fifo_cnt_d: std_logic_vector(0 to 9);
+Signal rd_fifo_cnt: std_logic_vector(0 to 9);
+Signal rxfifo_rec_256B: std_logic;
+Signal f_read_data_d: std_logic_vector(0 to 31);
+Signal f_read_data_q: std_logic_vector(0 to 31);
+Signal f_read_data_val_d: std_logic;
+Signal f_read_data_val_q: std_logic;
+Signal update_frval: std_logic;
+Signal flash_timeout: std_logic;
+Signal dsm_rst: std_logic;
+Signal dsm_p1: std_logic;
+Signal dsm_m1: std_logic;
+Signal dsm_to_s0x06: std_logic;
+Signal dsm_to_s0x08: std_logic;
+Signal drain_sm_p1: std_logic_vector(0 to 3);
+Signal drain_sm_m1: std_logic_vector(0 to 3);
+Signal drain_sm_nxt: std_logic_vector(0 to 3);
+Signal drain_sm_adv: std_logic;
+Signal drain_sm: std_logic_vector(0 to 3);
+Signal dsm_s0x00: std_logic;
+Signal dsm_s0x01: std_logic;
+Signal dsm_s0x02: std_logic;
+Signal dsm_s0x03: std_logic;
+Signal dsm_s0x04: std_logic;
+Signal dsm_s0x05: std_logic;
+Signal dsm_s0x06: std_logic;
+Signal dsm_s0x07: std_logic;
+Signal dsm_s0x08: std_logic;
+Signal byte_d: std_logic_vector(0 to 7);
+Signal byte_update: std_logic;
+Signal byte: std_logic_vector(0 to 7);
+Signal address_bytepos_d: std_logic_vector(0 to 1);
+Signal address_bytepos: std_logic_vector(0 to 1);
+Signal bit_pointer_d: std_logic_vector(0 to 2);
+Signal bit_pointer: std_logic_vector(0 to 2);
+Signal spi_mosi_d: std_logic;
+Signal spi_mosi_q: std_logic;
+Signal run_spi_clk: std_logic;
+Signal address: std_logic_vector(0 to 31);
+Signal address_d: std_logic_vector(0 to 31);
+Signal address_done: std_logic;
+Signal byte_xfer_complete: std_logic;
+Signal byte_rec_complete: std_logic;
+Signal spi_cs_q: std_logic;
+Signal data: std_logic_vector(0 to 7);
+Signal data_done: std_logic;
+Signal xfer_count: std_logic_vector(0 to 3);
+Signal xfer_count_d: std_logic_vector(0 to 3);
+Signal rec_count: std_logic_vector(0 to 3);
+Signal rec_count_d: std_logic_vector(0 to 3);
+Signal total_dbytes_d: std_logic_vector(0 to 7);
+Signal total_dbytes: std_logic_vector(0 to 7);
+Signal total_dbytes_update: std_logic;
+Signal spi_miso_q: std_logic;
+Signal in_byte_update: std_logic_vector(0 to 7);
+Signal in_byte_d: std_logic_vector(0 to 7);
+Signal in_byte: std_logic_vector(0 to 7);
+Signal flag_status: std_logic_vector(0 to 7);
+Signal flag_status_d: std_logic_vector(0 to 7);
+Signal flag_status_update: std_logic;
+Signal cs_counter_d: std_logic_vector(0 to 3);
+Signal cs_counterdone: std_logic;
+Signal cs_counter: std_logic_vector(0 to 3);
+Signal f_stat_erase_d: std_logic;
+Signal f_stat_erase_update: std_logic;
+Signal f_stat_pgm_d: std_logic;
+Signal f_stat_pgm_update: std_logic;
+Signal f_stat_read_d: std_logic;
+Signal f_stat_read_update: std_logic;
+Signal rst_clk_pulses: std_logic;
+Signal clk_pulses_d: std_logic_vector(0 to 3);
+Signal clk_pulses: std_logic_vector(0 to 3);
+Signal clk_exhausted: std_logic;
+Signal clk_exhausted_q: std_logic;
+Signal clk_exhausted_qq: std_logic;
+Signal clk_exhausted_qqq: std_logic;
+Signal clk_exhausted_qqqq: std_logic;
+
+Signal spi_mosi_startup: std_logic;
+Signal spi_clk_startup: std_logic;
+Signal spi_cen_startup: std_logic;
+--Signal spi_mosi: std_logic;
+--Signal spi_clk: std_logic;
+--Signal spi_cen: std_logic;
+--Signal spi_miso: std_logic;
+Signal clklogic: std_logic;
+Signal spicen: STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         spiclk : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         spimosi : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         spimiso : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         mainstate : STD_LOGIC_VECTOR(5 DOWNTO 0);
+Signal         drainstate : STD_LOGIC_VECTOR(3 DOWNTO 0);
+Signal         fiforeset : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         txpush : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         txpull : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         txwdata : STD_LOGIC_VECTOR(7 DOWNTO 0);
+Signal         txrdata : STD_LOGIC_VECTOR(7 DOWNTO 0);
+Signal         txempty : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         txfull : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         rxpush : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         rxpull : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         rxwdata : STD_LOGIC_VECTOR(7 DOWNTO 0);
+Signal         rxrdata : STD_LOGIC_VECTOR(7 DOWNTO 0);
+Signal         rxempty : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         rxfull : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         frdval : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal         frdack : STD_LOGIC_VECTOR(0 DOWNTO 0);
+Signal rxfifo_has_4B: std_logic;
+Signal rd_pull4B: std_logic;
+Signal rd_pull4B_q: std_logic;
+Signal rd_pull4B_q2: std_logic;
+Signal rd_pull4B_q3: std_logic;
+Signal rd_pull4B_q4: std_logic;
+Signal start_4B_xfer_d:std_logic;
+Signal start_4B_xfer:std_logic;
+Signal start_4B_xfer_en:std_logic;
+Signal start_4B_xfer_q:std_logic;
+
+begin
+
+  Z_v9bit <= (others => '0');
+  Z_v32bit <= (others => '0');
+  Z_v17bit <= (others => '0');
+  Z_v10bit <= (others => '0');
+
+--    version <= "00000000000000000000000000001100" ;
+
+clklogic <= psl_clk;
+spicen(0) <= spi_cs_q;
+spiclk(0) <= spi_clk_q;
+spimosi(0) <= spi_mosi_q;
+spimiso(0) <= spi_miso;
+mainstate <= main_sm;
+drainstate <= drain_sm;
+fiforeset(0) <= fifo_reset;
+txpush(0) <= pgm_fifo_push;
+txpull(0) <= pgm_fifo_pull;
+txempty(0) <= pgm_fifo_empty;
+txfull(0) <= pgm_fifo_full;
+txwdata <= pgm_fifo_wrdata;
+txrdata <= pgm_fifo_rddata;
+rxpush(0) <= rd_fifo_push;
+rxpull(0) <= rd_fifo_pull;
+rxempty(0) <= rd_fifo_empty;
+rxfull(0) <= rd_fifo_full;
+rxwdata <= rd_fifo_wrdata;
+rxrdata <= rd_fifo_rddata;
+frdval(0) <= f_read_data_val_q;
+frdack(0) <= f_read_data_ack;
+
+--============================================================================================
+---- Misc. Logic
+--==============================================================================================--
+
+    flash_busy <= not(flag_status(0)) ;
+    flash_error <= flag_status(0) and (flag_status(6) or flag_status(5) or flag_status(4) or flag_status(2) or flag_status(1)) ;
+    flash_timeout <= '0';
+
+ -- -- End Section -- --
+ -- ----------------------------------- --
+ -- Outputs                             --
+ -- ----------------------------------- --
+
+    pgm_remainder <= psm_bufcnt_q(0 to 9) when erase_complete='1' else esm_blkcnt_q(0 to 9);
+
+    f_remainder <= rsm_wrdcnt_q when f_read_req='1' else pgm_remainder;
+
+ -- -- End Section -- --
+
+--============================================================================================
+---- Main State
+--==============================================================================================--
+    ---- Nxt State always 0 if neither f_program_req or f_read_req set
+    ---- State 00  : IDLE                                           ----
+    ----            Nxt State 1 if f_program_req or f_read_req                              ----
+    ---- State 01  : Apply internal resets                                           ----
+    ----            Nxt State 2
+    ---- State 02  : Queue RESET ENABLE Command                    ----
+    ----            Nxt State 0F
+    ---- State 03  : Queue RESET MEMORY Command                                   ----
+    ----            Nxt State 0F
+    ---- State 04  : Queue ENTER 4B ADDRESS MODE Command                                        ----
+    ----            Nxt State 0F
+    ---- State 05  : Queue ENTER QUAD MODE Command                                           ----
+    ----            Nxt State 0F
+    ---- State 06  : Placeholder state for more commands            ----
+    ---- State 07  : Placeholder state for more commands            ----
+    ---- State 08  : Placeholder state for more commands            ----
+    ---- State 09  : Placeholder state for more commands            ----
+    ---- State 0A  : Placeholder state for more commands            ----
+    ---- State 0B  : Placeholder state for more commands            ----
+    ---- State 0C  : Placeholder state for more commands            ----
+    ---- State 0D  : Placeholder state for more commands            ----
+    ---- State 0E  : Placeholder state for more commands            ----
+    ---- State 0F  : Drain Commands/Address/Data into Target SPI                                        ----
+    ----            Nxt State return_state
+    ---- State 10 : ERASE/PROGRAM phase begin sample job size and                                          ----
+    ----            Nxt State 11
+    ---- State 11 : Queue CLEAR FLAG STATUS REGISTER command          ----
+    ----            Nxt State 0F
+    ---- State 12 : Queue WRITE ENABLE Command                                          ----
+    ----            Nxt State 0F
+    ---- State 13 : Queue SECTOR ERASE Command                                           ----
+    ----            Nxt State 0F
+    ---- State 14 : Queue READ FLAG STATUS REGISTER Command                   ----
+    ----            Nxt State 0F
+    ---- State 15 : Analyze Current Status                                           ----
+    ----            Nxt State 14 if flash_busy and no flash_timeout
+    ----            Nxt State 2F if flash_error or flash_timeout
+    ----            Nxt State 16 if not flash_busy and not flash_error
+    ---- State 16 : Update Address and Remaining Job Size                   ----
+    ----            Nxt State 11 if more2erase                               ----
+    ----            Nxt State 17 if erase complete                               ----
+    ---- State 17 : PROGRAM ROUTINE: Reset address, job size; Indicate Erase is complete                                           ----
+    ----            Nxt State 18
+    ---- State 18 : Queue CLEAR FLAG STATUS REGISTER Command
+    ----            Nxt State 0F
+    ---- State 19 : Queue WRITE ENABLE Command                                           ----
+    ----            Nxt State 0F
+    ---- State 1A : Queue 4B ADDRESS PAGE PROGRAM Command AND Wait for 256 bytes data in tx fifo                                           ----
+    ----            Nxt State 0F
+    ---- State 1B : Queue READ FLAGS STATUS REGISTER Command
+    ----            Nxt State 0F
+    ---- State 1C : Analyze Current Status                                           ----
+    ----            Nxt State 1B if flash_busy and no flash_timeout
+    ----            Nxt State 2F if flash_error or flash_timeout
+    ----            Nxt State 1D if not flash_busy and not flash_error                                           ----
+    ---- State 1D : Update Address and Remaining Job Size
+    ----            Nxt State 18 if more2pgm
+    ----            Nxt State 2E if not more2pgm
+    ---- State 2E : Indicate Erase/Program finished w/o errors                                           ----
+    ----            Nxt State 2E if f_program_req
+    ----            Nxt State 00 if not f_program_req
+    ---- State 2F : Indicate Erase/Program errored out
+    ----            Nxt State 2F if f_program_req
+    ----            Nxt State 00 if not f_program_req
+    ---- State 30 : READ Routine: Sample Starting Address and Job size.
+    ----            Nxt State 31
+    ---- State 31 : Queue READ Command And Wait for 256 bytes free in read buffer                                 ----
+    ----            Nxt State 0F
+    ---- State 32 : Update address and job size left                                           ----
+    ----            Nxt State 31 if more2read
+    ----            Nxt State 3E if not more2read
+    ---- State 3E : Indicate Read finished w/o errors                   ----
+    ----            Nxt State 3E if f_read_req
+    ----            Nxt State 00 if not f_read_req
+
+ -- ----------------------------------- --
+ -- Next State Equations and SM Latch   --
+ -- ----------------------------------- --
+
+    pgm_rd_req <= f_program_req  or  f_read_req ;
+
+    ---- Next State Controls ----
+    msm_rst <= not(pgm_rd_req) ;    -- Reset State Machine when program is complete --
+    msm_to_s0x0F <= (msm_s0x02 or msm_s0x03 or msm_s0x04 or msm_s0x05  or msm_s0x11 or msm_s0x12 or msm_s0x13 or msm_s0x14 or msm_s0x18 or msm_s0x19 or msm_s0x1A or msm_s0x1B or msm_s0x31) and not(msm_rst);
+    msm_p1 <= (msm_s0x00 or msm_s0x01 or msm_s0x10 or (msm_s0x16 and not(more2erase)) or (msm_s0x15 and not(flash_busy or flash_timeout or flash_error))  or (msm_s0x1C and not(flash_busy or flash_timeout or flash_error)) or msm_s0x17 or msm_s0x30) and not(msm_rst);
+    msm_return <= (msm_s0x0F) and not(msm_rst);
+    msm_to_s0x11 <= msm_s0x16 and more2erase and not(msm_rst);
+    msm_to_s0x18 <= msm_s0x1D and more2pgm and not(msm_rst);
+    msm_to_s0x31 <= msm_s0x32 and more2read and not(msm_rst);
+    msm_to_s0x14 <= msm_s0x15 and flash_busy and not(flash_error or flash_timeout) and not(msm_rst);
+    msm_to_s0x2E <= (msm_s0x1D and not(more2pgm)) and not(msm_rst);
+    msm_to_s0x3E <= (msm_s0x32 and not(more2read)) and not(msm_rst);
+    msm_to_s0x2F <= ((msm_s0x15 and (flash_error or flash_timeout)) or (msm_s0x1C and (flash_error or flash_timeout))) and not(msm_rst);
+    msm_to_s0x1B <= msm_s0x1C and flash_busy and not(flash_error or flash_timeout) and not(msm_rst);
+
+    -----------------------------
+
+    ---- Next State ----
+    main_sm_p1 <=  std_logic_vector(unsigned(main_sm) + 1) ;
+    main_sm_nxt <= gate_and(msm_p1,main_sm_p1) or
+                    gate_and(msm_to_s0x0F,"001111") or
+                    gate_and(msm_to_s0x11,"010001") or
+                    gate_and(msm_to_s0x14,"010100") or
+                    gate_and(msm_to_s0x18,"011000") or
+                    gate_and(msm_to_s0x1B,"011011") or
+                    gate_and(msm_to_s0x2E,"101110") or
+                    gate_and(msm_to_s0x3E,"111110") or
+                    gate_and(msm_to_s0x2F,"101111") or
+                    gate_and(msm_to_s0x31,"110001") or
+                    gate_and(msm_return,msm_returnstate) or
+                    gate_and(msm_rst,"000000");
+    main_sm_adv <= (not(pgm_rd_req) or (msm_s0x00 and pgm_rd_req) or (msm_s0x0F and dsm_s0x08 and drain_sm_adv)  or (msm_s0x1A and txfifo_has_256B) or (msm_s0x31 and rxfifo_rec_256B)
+                   or not(msm_s0x00 or msm_s0x0F or msm_s0x1A or msm_s0x2E or msm_s0x2F or msm_s0x31 or msm_s0x3E));
+
+    dff_main_sm: capi_en_rise_vdff GENERIC MAP ( width => 6 ) PORT MAP (
+         dout => main_sm,
+         en => main_sm_adv,
+         din => main_sm_nxt,
+         clk   => psl_clk
+    );
+
+    msm_return_p1 <= msm_s0x02 or msm_s0x03 or msm_s0x11 or msm_s0x12 or msm_s0x13 or msm_s0x14 or msm_s0x18 or msm_s0x19 or msm_s0x1A or msm_s0x1B or msm_s0x31;
+    msm_return_pgm <= msm_s0x04 and f_program_req and not(f_read_req);
+    msm_return_read <= msm_s0x04 and f_read_req;
+    msm_returnstate_update <= msm_s0x02 or msm_s0x03 or msm_s0x04 or msm_s0x05 or msm_s0x11 or msm_s0x12 or msm_s0x13 or msm_s0x14 or msm_s0x18 or msm_s0x19 or msm_s0x1A or msm_s0x1B or msm_s0x31;
+    msm_returnstate_d <= gate_and(msm_return_p1,main_sm_p1) or
+                       gate_and(msm_return_pgm,"010000") or
+                       gate_and(msm_return_read,"110000");--Move on from state 4 and skip quad mode for now
+
+    dff_msm_returnstate: capi_en_rise_vdff GENERIC MAP ( width => 6 ) PORT MAP (
+         dout => msm_returnstate,
+         en => msm_returnstate_update,
+         din => msm_returnstate_d,
+         clk   => psl_clk
+    );
+--Main State machine decodes
+    msm_s0x00 <= '1' when (main_sm  =  "000000") else '0';     -- 0x00  --
+    msm_s0x01 <= '1' when (main_sm  =  "000001") else '0';     -- 0x01  --
+    msm_s0x02 <= '1' when (main_sm  =  "000010") else '0' ;     -- 0x02  --
+    msm_s0x03 <= '1' when (main_sm  =  "000011") else '0' ;     -- 0x03  --
+    msm_s0x04 <= '1' when (main_sm  =  "000100") else '0' ;     -- 0x04  --
+    msm_s0x05 <= '1' when (main_sm  =  "000101") else '0' ;     -- 0x05  --
+    msm_s0x0F <= '1' when (main_sm  =  "001111") else '0' ;     -- 0x0F  --
+    msm_s0x10 <= '1' when (main_sm  =  "010000") else '0' ;     -- 0x10  --
+    msm_s0x11 <= '1' when (main_sm  =  "010001") else '0' ;     -- 0x11  --
+    msm_s0x12 <= '1' when (main_sm  =  "010010") else '0' ;     -- 0x12  --
+    msm_s0x13 <= '1' when (main_sm  =  "010011") else '0' ;     -- 0x13  --
+    msm_s0x14 <= '1' when (main_sm  =  "010100") else '0' ;     -- 0x14  --
+    msm_s0x15 <= '1' when (main_sm  =  "010101") else '0' ;     -- 0x15  --
+    msm_s0x16 <= '1' when (main_sm  =  "010110") else '0' ;     -- 0x16  --
+    msm_s0x17 <= '1' when (main_sm  =  "010111") else '0' ;     -- 0x17  --
+    msm_s0x18 <= '1' when (main_sm  =  "011000") else '0' ;     -- 0x18  --
+    msm_s0x19 <= '1' when (main_sm  =  "011001") else '0' ;     -- 0x19  --
+    msm_s0x1A <= '1' when (main_sm  =  "011010") else '0' ;     -- 0x1A  --
+    msm_s0x1B <= '1' when (main_sm  =  "011011") else '0' ;     -- 0x1B  --
+    msm_s0x1C <= '1' when (main_sm  =  "011100") else '0' ;     -- 0x1C  --
+    msm_s0x1D <= '1' when (main_sm  =  "011101") else '0' ;     -- 0x1D  --
+    msm_s0x2E <= '1' when (main_sm  =  "101110") else '0' ;     -- 0x2E  --
+    msm_s0x2F <= '1' when (main_sm  =  "101111") else '0' ;     -- 0x2F  --
+    msm_s0x30 <= '1' when (main_sm  =  "110000") else '0' ;     -- 0x30  --
+    msm_s0x31 <= '1' when (main_sm  =  "110001") else '0' ;     -- 0x31  --
+    msm_s0x32 <= '1' when (main_sm  =  "110010") else '0' ;     -- 0x32  --
+    msm_s0x3E <= '1' when (main_sm  =  "111110") else '0' ;     -- 0x3E  --
+
+   f_stat_erase_d <= '1' when ((msm_s0x00 = '1') and (f_program_req = '1')) else '0';
+   f_stat_pgm_d <= '1' when ((msm_s0x00 = '1') and (f_program_req = '1')) else '0';
+   f_stat_read_d <= '1' when ((msm_s0x00 = '1') and (f_read_req = '1')) else '0';
+   f_stat_erase_update <= msm_s0x00 or msm_s0x17;
+   f_stat_pgm_update <= msm_s0x00 or msm_s0x2E;
+   f_stat_read_update <= msm_s0x00 or msm_s0x3E;
+   dff_f_stat_erase: capi_en_rise_dff PORT MAP (
+         dout => f_stat_erase,
+         en => f_stat_erase_update,
+         din => f_stat_erase_d,
+         clk   => psl_clk
+    );
+   dff_f_stat_pgm: capi_en_rise_dff PORT MAP (
+         dout => f_stat_program,
+         en => f_stat_pgm_update,
+         din => f_stat_pgm_d,
+         clk   => psl_clk
+    );
+   dff_f_stat_read: capi_en_rise_dff PORT MAP (
+         dout => f_stat_read,
+         en => f_stat_read_update,
+         din => f_stat_read_d,
+         clk   => psl_clk
+    );
+
+ -- -- End Section -- --
+
+ -- ----------------------------------- --
+ -- Cycle Timer                         --
+ -- ----------------------------------- --
+
+    start_dly <= '1' when ((drain_sm_nxt = "0011") or (drain_sm_nxt = "0101") or (drain_sm_nxt = "0111")) else '0';
+    new_dly <= "0000000000000000";
+    cycdly_m1 <= std_logic_vector(unsigned(cycdly_q) + 1);
+
+    cycdly_d <= new_dly when (start_dly ='1') else cycdly_m1;
+    cnt_en <= '1' ;
+    endff_cycdly_q: capi_en_rise_vdff GENERIC MAP ( width => 16 ) PORT MAP (
+         dout => cycdly_q,
+         en => cnt_en,
+         din => cycdly_d,
+         clk   => psl_clk
+    );
+
+    dly_done <= '1' when (cycdly_q = "0000010000010100") else '0';
+
+ -- -- End Section -- --
+
+ -- ----------------------------------- --
+ -- Command Constants                   --
+ -- ----------------------------------- --
+
+qspi_rst_en <= X"66";--Command only
+qspi_rst_mem <= X"99";--Command only
+qspi_enter_4B_addr <= X"B7";--Command Only
+qspi_enter_quad_mode <= X"35";--Command Only
+qspi_we <= X"06";--Command only
+qspi_4B_read <= X"13";--Com-Adr-Data--
+qspi_fstatus_read <= X"70";--Command then Data--
+qspi_fstatus_clear <= X"50";--Command Only
+qspi_4B_page_pgm <= X"12";--Com-Adr-Data--
+qspi_sector_erase <= X"D8";--Command then Address
+
+
+ -- ----------------------------------- --
+ -- Main SM Outputs                     --
+ -- ----------------------------------- --
+    frstn <=  not (main_sm(2)  or  main_sm(5)) ;
+
+    program_flash <= main_sm(4)  and  f_program_req ;
+    read_flash <= main_sm(4)  and  f_read_req ;
+
+    init_cnt_adr <= main_sm(0) ;
+
+    f_ready <= msm_s0x00;
+    f_done <= msm_s0x2E or msm_s0x2F or msm_s0x3E;
+ -- -- End Section -- --
+
+--============================================================================================
+---- Settings per command or as a result of issuing certain commands
+--==============================================================================================--
+
+     --TODO: Support quad mode reads/writes?
+     quad_mode_update <= msm_s0x01 or msm_s0x05;
+     quad_mode_d <= '1' when (msm_s0x05 = '1') else '0';
+     endff_quad_mode_q: capi_en_rise_dff PORT MAP (
+         dout => quad_mode,
+         en => quad_mode_update,
+         din => quad_mode_d,
+         clk   => psl_clk
+    );
+
+     fourB_address_mode_update <= msm_s0x01 or msm_s0x04;
+     fourB_address_mode_d <= '1' when (msm_s0x04 = '1') else '0';
+     endff_fourB_address_mode_q: capi_en_rise_dff PORT MAP (
+         dout => fourB_address_mode,
+         en => fourB_address_mode_update,
+         din => fourB_address_mode_d,
+         clk   => psl_clk
+    );
+
+     command_sent <= '1';
+
+     address_sent_update <= msm_s0x02 or msm_s0x03 or msm_s0x04 or msm_s0x05 or msm_s0x11 or msm_s0x12 or msm_s0x13 or msm_s0x14 or msm_s0x18 or msm_s0x19 or msm_s0x1A or msm_s0x1B or msm_s0x31;
+     address_sent_d <= '1' when ((msm_s0x13 = '1') or (msm_s0x1A = '1') or (msm_s0x31 = '1')) else '0';
+     endff_address_sent_q: capi_en_rise_dff PORT MAP (
+         dout =>address_sent,
+         en => address_sent_update,
+         din => address_sent_d,
+         clk   => psl_clk
+    );
+
+     data_sent_update <= msm_s0x02 or msm_s0x03 or msm_s0x04 or msm_s0x05 or msm_s0x11 or msm_s0x12 or msm_s0x13 or msm_s0x14 or msm_s0x18 or msm_s0x19 or msm_s0x1A or msm_s0x1B or msm_s0x31;
+     data_sent_d <= '1' when ((msm_s0x14 = '1') or (msm_s0x1A = '1') or (msm_s0x1B = '1') or (msm_s0x31 = '1')) else '0';
+     endff_data_sent_q: capi_en_rise_dff PORT MAP (
+         dout =>data_sent,
+         en => data_sent_update,
+         din => data_sent_d,
+         clk   => psl_clk
+    );
+
+    start_address_update <= msm_s0x01;
+    start_address_d <= f_read_start_addr;
+    endff_start_address_q: capi_en_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => start_address,
+         en => start_address_update,
+         din => start_address_d,
+         clk   => psl_clk
+    );
+
+    start_sectors_update <= msm_s0x01;
+    start_sectors_d <= f_num_blocks; --Size in 64KB sectors
+    endff_start_size_q: capi_en_rise_vdff GENERIC MAP ( width => 16 ) PORT MAP (
+         dout => start_sectors,
+         en => start_sectors_update,
+         din => start_sectors_d,
+         clk   => psl_clk
+    );
+
+    command_update <= msm_to_s0x0F;
+    command_d <= gate_and(msm_s0x02, qspi_rst_en) or
+                 gate_and(msm_s0x03, qspi_rst_mem) or
+                 gate_and(msm_s0x04, qspi_enter_4B_addr) or
+                 gate_and(msm_s0x05, qspi_enter_quad_mode) or
+                 gate_and(msm_s0x11 or msm_s0x18, qspi_fstatus_clear) or
+                 gate_and(msm_s0x12 or msm_s0x19, qspi_we) or
+                 gate_and(msm_s0x14 or msm_s0x1B, qspi_fstatus_read) or
+                 gate_and(msm_s0x31, qspi_4B_read) or
+                 gate_and(msm_s0x1A, qspi_4B_page_pgm) or
+                 gate_and(msm_s0x13, qspi_sector_erase);
+    endff_command_q: capi_en_rise_vdff GENERIC MAP ( width => 8 ) PORT MAP (
+         dout => command,
+         en => command_update,
+         din => command_d,
+         clk   => psl_clk
+    );
+
+    read_speed_d <= '1' when ((msm_s0x14 = '1') or (msm_s0x1B = '1') or (msm_s0x31 = '1')) else '0';
+    read_speed_update <= msm_to_s0x0F;
+    endff_read_speed_q: capi_en_rise_dff PORT MAP (
+         dout => read_speed,
+         en => read_speed_update,
+         din => read_speed_d,
+         clk   => psl_clk
+    );
+
+--============================================================================================
+---- Address and Job size tracking
+--==============================================================================================--
+
+ -- ----------------------------------- --
+ -- Block Address                       --
+ -- ----------------------------------- --
+
+    esm_blkadr_p1 <= std_logic_vector(unsigned(esm_blkadr_q) + 1) ;
+
+    esm_blkadr_d <= start_address(0 to 15) when msm_s0x10='1' else esm_blkadr_p1;
+
+    --bool esm_update_blkadr = (init_cnt_adr | esm_s0x11);--
+    msm_update_blkadr <= (msm_s0x10 or msm_s0x16) ;
+
+    endff_esm_blkadr_q: capi_en_rise_vdff GENERIC MAP ( width => 16 ) PORT MAP (
+         dout => esm_blkadr_q,
+         en => msm_update_blkadr,
+         din => esm_blkadr_d,
+         clk   => psl_clk
+    );
+    endff_msm_update_blkadr_q: capi_rise_dff PORT MAP (
+         dout => msm_update_blkadr_q,
+         din => msm_update_blkadr,
+         clk   => psl_clk
+    );
+
+    esm_blkadr <= esm_blkadr_q & "0000000000000000"; --64KiB address so lower 16 bits are 0
+ -- -- End Section -- --
+
+ -- ----------------------------------- --
+ -- 256B Write/Read Address                       --
+ -- ----------------------------------- --
+
+    msm_byteadr_p1 <=std_logic_vector(unsigned(msm_byteadr_q) + 1) ;
+
+    msm_byteadr_d <= (start_address(0 to 23)) when ((msm_s0x30='1') or (msm_s0x17='1')) else msm_byteadr_p1;
+
+    --bool esm_update_blkadr = (init_cnt_adr | esm_s0x11);--
+    msm_update_byteadr <= (msm_s0x17 or msm_s0x1D or msm_s0x30 or msm_s0x32) ;
+
+    endff_msm_byteadr_q: capi_en_rise_vdff GENERIC MAP ( width => 24 ) PORT MAP (
+         dout => msm_byteadr_q,
+         en => msm_update_byteadr,
+         din => msm_byteadr_d,
+         clk   => psl_clk
+    );
+    endff_msm_update_byteadr_q: capi_rise_dff PORT MAP (
+         dout => msm_update_byteadr_q,
+         din => msm_update_byteadr,
+         clk   => psl_clk
+    );
+
+    msm_byteadr <= msm_byteadr_q & "00000000"; --256 byte address so lower 8 bits are 0
+
+    address_d <= esm_blkadr when (msm_update_blkadr_q = '1') else
+               msm_byteadr when (msm_update_byteadr_q = '1') else
+               address;
+    dff_address_q: capi_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => address,
+         din => address_d,
+         clk   => psl_clk
+    );
+
+ -- ----------------------------------- --
+ -- Count of Blocks to Erase            --
+ -- ----------------------------------- --
+    esm_blkcnt_m1 <= std_logic_vector(unsigned(esm_blkcnt_q) - 1) ;
+
+    esm_blkcnt_d <= start_sectors when msm_s0x10='1' else esm_blkcnt_m1;
+
+
+    esm_update_blkcnt <= msm_s0x10 or msm_s0x16 ;
+
+    endff_esm_blkcnt_q: capi_en_rise_vdff GENERIC MAP ( width => 16 ) PORT MAP (
+         dout => esm_blkcnt_q,
+         en => esm_update_blkcnt,
+         din => esm_blkcnt_d,
+         clk   => psl_clk
+    );
+
+    more2erase <= or_reduce(esm_blkcnt_q);
+
+ -- ----------------------------------- --
+ -- Count of 256B Writes/Reads            --
+ -- ----------------------------------- --
+    msm_bytecnt_m1 <= std_logic_vector(unsigned(msm_bytecnt_q) - 1) ;
+    --msm_bytecnt_m1 <= msm_bytecnt_q - msm_bytecnt_q; --SIMONLY!! for lab use above line
+
+    msm_bytecnt_d <= (start_sectors & "00000000")  when ((msm_s0x17='1') or (msm_s0x30='1')) else msm_bytecnt_m1;
+
+
+    msm_update_bytecnt <= msm_s0x17 or msm_s0x1D or msm_s0x30 or msm_s0x32;
+
+    endff_msm_bytecnt_q: capi_en_rise_vdff GENERIC MAP ( width => 24 ) PORT MAP (
+         dout => msm_bytecnt_q,
+         en => msm_update_bytecnt,
+         din => msm_bytecnt_d,
+         clk   => psl_clk
+    );
+    msm_bytecnt <= msm_bytecnt_q;
+
+    more2pgm <= or_reduce(msm_bytecnt_q);
+    more2read <= or_reduce(msm_bytecnt_q);
+
+ -- -- End Section -- --
+
+ -- ----------------------------------- --
+ -- State 0x0F -- Com/Adr/Data Flush    --
+ -- ----------------------------------- --
+
+--============================================================================================
+---- Command/Address/Data Drain State
+--==============================================================================================--
+    ---- Nxt State always 0 if neither f_program_req or f_read_req set
+    ---- State 00  : IDLE                                           ----
+    ----            Nxt State 1                              ----
+    ---- State 01  : Target Command Byte                                           ----
+    ----            Nxt State 2
+    ---- State 02  : Pulse Chip Select to active                    ----
+    ----            Nxt State 3
+    ---- State 03  : Drain Command Byte at appropriate clock speed                                   ----
+    ----            Nxt State 4 if address to be sent
+    ----            Nxt State 6 if no address but data to send
+    ----            Nxt State 8 if no address or data to send
+    ---- State 04  : Target Address Byte                                        ----
+    ----            Nxt State 5
+    ---- State 05  : Drain Address Byte                                           ----
+    ----            Nxt State 4 if more address bytes
+    ----            Nxt State 6 if no more address and data to send
+    ----            Nxt State 8 if no more address and no data to send
+    ---- State 06  : Target Data Byte            ----
+    ----            Nxt State 7
+    ---- State 07  : Drain Data Byte            ----
+    ----            Nxt State 6 if more data bytes
+    ----            Nxt State 8 if no more data to send
+    ---- State 08  : Deactivate chip select. indicate xfer complete            ----
+
+ -- ----------------------------------- --
+ -- Next State Equations and SM Latch   --
+ -- ----------------------------------- --
+
+    ---- Next State Controls ----
+    dsm_rst <= not(msm_s0x0F) ;    -- Reset State Machine when program is complete --
+    dsm_p1 <= (dsm_s0x00 or dsm_s0x01 or dsm_s0x02 or (dsm_s0x03 and address_sent) or dsm_s0x04  or (dsm_s0x05 and data_sent and address_done) or dsm_s0x06  or (dsm_s0x07 and data_done)) and not(dsm_rst);
+    dsm_m1 <= ((dsm_s0x05 and not(address_done)) or (dsm_s0x07 and not(data_done))) and not(dsm_rst);
+    dsm_to_s0x06 <= (dsm_s0x03 and not(address_sent) and data_sent) and not(dsm_rst);
+    dsm_to_s0x08 <= ((dsm_s0x03 and not(address_sent) and not(data_sent)) or (dsm_s0x05 and address_done and not(data_sent))) and not(dsm_rst);
+    -----------------------------
+
+    ---- Next State ----
+    drain_sm_p1 <= std_logic_vector(unsigned(drain_sm) + 1) ;
+    drain_sm_m1 <= std_logic_vector(unsigned(drain_sm) - 1) ;
+    drain_sm_nxt <= gate_and(dsm_p1,drain_sm_p1) or
+                    gate_and(dsm_m1,drain_sm_m1) or
+                    gate_and(dsm_to_s0x06,"0110") or
+                    gate_and(dsm_to_s0x08,"1000") or
+                    gate_and(dsm_rst,"0000");
+    drain_sm_adv <= (not(dsm_s0x03) and not(dsm_s0x05) and not(dsm_s0x07) and not(dsm_s0x02) and not(dsm_s0x08))  or (clk_exhausted_qqq and clk_exhausted and clk_exhausted_q and clk_exhausted_qq and (dsm_s0x03 or dsm_s0x05 or dsm_s0x07)) or ((dsm_s0x02 or dsm_s0x08) and cs_counterdone);
+
+    dff_drain_sm: capi_en_rise_vdff GENERIC MAP ( width => 4 ) PORT MAP (
+         dout => drain_sm,
+         en => drain_sm_adv,
+         din => drain_sm_nxt,
+         clk   => psl_clk
+    );
+
+--Drain State machine decodes
+    dsm_s0x00 <= '1' when (drain_sm  =  "0000") else '0';     -- 0x00  --
+    dsm_s0x01 <= '1' when (drain_sm  =  "0001") else '0';     -- 0x01  --
+    dsm_s0x02 <= '1' when (drain_sm  =  "0010") else '0';     -- 0x02  --
+    dsm_s0x03 <= '1' when (drain_sm  =  "0011") else '0';     -- 0x03  --
+    dsm_s0x04 <= '1' when (drain_sm  =  "0100") else '0';     -- 0x04  --
+    dsm_s0x05 <= '1' when (drain_sm  =  "0101") else '0';     -- 0x05  --
+    dsm_s0x06 <= '1' when (drain_sm  =  "0110") else '0';     -- 0x06  --
+    dsm_s0x07 <= '1' when (drain_sm  =  "0111") else '0';     -- 0x07  --
+    dsm_s0x08 <= '1' when (drain_sm  =  "1000") else '0';     -- 0x08  --
+
+
+    cs_counter_d <= "0000" when ((dsm_s0x02 = '0') and (dsm_s0x08 = '0')) else std_logic_vector(unsigned(cs_counter) + 1);
+    dff_cs_counter: capi_rise_vdff GENERIC MAP ( width => 4 ) PORT MAP (
+         dout => cs_counter,
+         din => cs_counter_d,
+         clk   => psl_clk
+    );
+    cs_counterdone <= '1' when (cs_counter = "1111") else '0';
+
+    --Flash memory flag status register
+    flag_status_update <= '1' when ((dsm_s0x08 = '1') and (drain_sm_adv = '1') and (command = qspi_fstatus_read)) else '0';
+    flag_status_d <= in_byte;
+    dff_flag_status: capi_en_rise_vdff GENERIC MAP ( width => 8 ) PORT MAP (
+         dout => flag_status,
+         en => flag_status_update,
+         din => flag_status_d,
+         clk   => psl_clk
+    );
+
+ -- ----------------------------------- --
+ -- Byte Select                 --
+ -- ----------------------------------- --
+
+byte_d <= command when (dsm_s0x01 = '1') else
+          address(0 to 7) when ((dsm_s0x04 = '1') and (address_bytepos = "00")) else
+          address(8 to 15) when ((dsm_s0x04 = '1') and (address_bytepos = "01")) else
+          address(16 to 23) when ((dsm_s0x04 = '1') and (address_bytepos = "10")) else
+          address(24 to 31) when ((dsm_s0x04 = '1') and (address_bytepos = "11")) else
+          data;
+byte_update <= dsm_s0x01 or dsm_s0x04 or dsm_s0x06;
+
+    dff_byte: capi_en_rise_vdff GENERIC MAP ( width => 8 ) PORT MAP (
+         dout => byte,
+         en => byte_update,
+         din => byte_d,
+         clk   => psl_clk
+    );
+
+address_bytepos_d <= "00" when (msm_to_s0x0F = '1') and (fourB_address_mode = '1') else
+                     "01" when (msm_to_s0x0F = '1') and (fourB_address_mode = '0') else
+                     std_logic_vector(unsigned(address_bytepos) + 1) when ((dsm_s0x05 = '1') and (drain_sm_adv = '1')) else
+                     address_bytepos;
+
+    dff_address_bytepos: capi_rise_vdff GENERIC MAP ( width => 2 ) PORT MAP (
+         dout => address_bytepos,
+         din => address_bytepos_d,
+         clk   => psl_clk
+    );
+
+address_done <= '1' when (dsm_s0x05 = '1' and (address_bytepos = "11")) else
+                '0';
+
+    total_dbytes_d <= "11111111" when ((msm_s0x1A = '1') or (msm_s0x31 = '1')) else
+                      std_logic_vector(unsigned(total_dbytes) - 1) when (dsm_s0x07 = '1') else
+                     "00000000";
+    total_dbytes_update <= msm_s0x1A or msm_s0x31 or msm_s0x14 or msm_s0x1B or (dsm_s0x07 and drain_sm_adv);
+    endff_total_dbytes_q: capi_en_rise_vdff GENERIC MAP ( width => 8 ) PORT MAP (
+         dout => total_dbytes,
+         en => total_dbytes_update,
+         din => total_dbytes_d,
+         clk   => psl_clk
+    );
+
+data_done <= not(or_reduce(total_dbytes));
+ -- ----------------------------------- --
+ -- Bit(s) Select and data out                --
+ -- ----------------------------------- --
+-- TODO: Add quad mode support.
+
+bit_pointer_d <= "111" when (dsm_s0x00 = '1') else
+                 std_logic_vector(unsigned(bit_pointer) + 1) when ((spi_clk_d = '0') and (spi_clk_q = '1')) else
+                 bit_pointer;
+    dff_bit_pointer: capi_rise_vdff GENERIC MAP ( width => 3 ) PORT MAP (
+         dout => bit_pointer,
+         din => bit_pointer_d,
+         clk   => psl_clk
+    );
+
+spi_mosi_d <= byte(0) when (bit_pointer_d = "000") else
+              byte(1) when (bit_pointer_d = "001") else
+              byte(2) when (bit_pointer_d = "010") else
+              byte(3) when (bit_pointer_d = "011") else
+              byte(4) when (bit_pointer_d = "100") else
+              byte(5) when (bit_pointer_d = "101") else
+              byte(6) when (bit_pointer_d = "110") else
+              byte(7);
+
+    dff_spi_mosi_q: capi_rise_dff PORT MAP (
+         dout => spi_mosi_q,
+         din => spi_mosi_d,
+         clk   => psl_clk
+    );
+
+    dff_spi_mosi: capi_rise_dff PORT MAP (
+         dout => spi_mosi,
+         din => spi_mosi_q,
+         clk   => psl_clk
+    );
+
+   xfer_count_d <= "0000" when ((dsm_s0x03 = '0') and (dsm_s0x05 = '0') and (dsm_s0x07 = '0')) else
+                   std_logic_vector(unsigned(xfer_count) + 1) when ((spi_clk_d = '1') and (spi_clk_q = '0')) else
+                   xfer_count;
+    dff_xfer_count: capi_rise_vdff GENERIC MAP ( width => 4 ) PORT MAP (
+         dout => xfer_count,
+         din => xfer_count_d,
+         clk   => psl_clk
+    );
+
+   byte_xfer_complete <= '1' when (xfer_count = "1000") else
+                         '0';
+
+    dff_spi_miso: capi_rise_dff PORT MAP (
+         dout => spi_miso_q,
+         din => spi_miso,
+         clk   => psl_clk
+    );
+
+in_byte_d <= spi_miso & spi_miso & spi_miso & spi_miso & spi_miso & spi_miso & spi_miso & spi_miso;
+in_byte_update(0) <= '1' when ((spi_clk_qq = '0') and (spi_clk_int = '1') and (dsm_s0x07 = '1') and (bit_pointer = "000")) else '0';
+in_byte_update(1) <= '1' when ((spi_clk_qq = '0') and (spi_clk_int = '1') and (dsm_s0x07 = '1') and bit_pointer = "001") else '0';
+in_byte_update(2) <= '1' when ((spi_clk_qq = '0') and (spi_clk_int = '1') and (dsm_s0x07 = '1') and bit_pointer = "010") else '0';
+in_byte_update(3) <= '1' when ((spi_clk_qq = '0') and (spi_clk_int = '1') and (dsm_s0x07 = '1') and bit_pointer = "011") else '0';
+in_byte_update(4) <= '1' when ((spi_clk_qq = '0') and (spi_clk_int = '1') and (dsm_s0x07 = '1') and bit_pointer = "100") else '0';
+in_byte_update(5) <= '1' when ((spi_clk_qq = '0') and (spi_clk_int = '1') and (dsm_s0x07 = '1') and bit_pointer = "101") else '0';
+in_byte_update(6) <= '1' when ((spi_clk_qq = '0') and (spi_clk_int = '1') and (dsm_s0x07 = '1') and bit_pointer = "110") else '0';
+in_byte_update(7) <= '1' when ((spi_clk_qq = '0') and (spi_clk_int = '1') and ((dsm_s0x07 = '1') or (dsm_s0x06 = '1') or (dsm_s0x08 = '1')) and bit_pointer = "111") else '0';
+
+    dff_in_byte_0: capi_en_rise_dff PORT MAP (
+         dout => in_byte(0),
+         en => in_byte_update(0),
+         din => in_byte_d(0),
+         clk   => psl_clk
+    );
+    dff_in_byte_1: capi_en_rise_dff PORT MAP (
+         dout => in_byte(1),
+         en => in_byte_update(1),
+         din => in_byte_d(1),
+         clk   => psl_clk
+    );
+    dff_in_byte_2: capi_en_rise_dff PORT MAP (
+         dout => in_byte(2),
+         en => in_byte_update(2),
+         din => in_byte_d(2),
+         clk   => psl_clk
+    );
+    dff_in_byte_3: capi_en_rise_dff PORT MAP (
+         dout => in_byte(3),
+         en => in_byte_update(3),
+         din => in_byte_d(3),
+         clk   => psl_clk
+    );
+    dff_in_byte_4: capi_en_rise_dff PORT MAP (
+         dout => in_byte(4),
+         en => in_byte_update(4),
+         din => in_byte_d(4),
+         clk   => psl_clk
+    );
+    dff_in_byte_5: capi_en_rise_dff PORT MAP (
+         dout => in_byte(5),
+         en => in_byte_update(5),
+         din => in_byte_d(5),
+         clk   => psl_clk
+    );
+    dff_in_byte_6: capi_en_rise_dff PORT MAP (
+         dout => in_byte(6),
+         en => in_byte_update(6),
+         din => in_byte_d(6),
+         clk   => psl_clk
+    );
+    dff_in_byte_7: capi_en_rise_dff PORT MAP (
+         dout => in_byte(7),
+         en => in_byte_update(7),
+         din => in_byte_d(7),
+         clk   => psl_clk
+    );
+ -- ----------------------------------- --
+ -- Drive Outputs                 --
+ -- ----------------------------------- --
+
+    --Must Generate SPI Clock with proper phase to data, polarity, and frequency
+    --PSL Clock is 250 MHz. STR write commands can be 133MHz, do a div 2 125MHz clock will work for writes
+    -- STR reads max freq is 66MHz, so a div 4 62.5MHz clock will work for reads
+    -- For polarity, clock should init to 1
+    -- For phase, the qspi samples on rising edge, so data should be supplied on falling edge
+    rst_clk_pulses <= '1' when (((drain_sm_nxt = "0011") or (drain_sm_nxt = "0101") or (drain_sm_nxt = "0111")) and (drain_sm_adv = '1')) else '0';
+    clk_pulses_d <= "1000" when (rst_clk_pulses = '1') else
+                    std_logic_vector(unsigned(clk_pulses) - 1) when ((spi_clk_d = '1') and (spi_clk_q = '0')) else
+                    clk_pulses;
+    dff_clk_pulses: capi_rise_vdff GENERIC MAP ( width => 4 ) PORT MAP (
+         dout => clk_pulses,
+         din => clk_pulses_d,
+         clk   => psl_clk
+    );
+
+    clk_exhausted <= not(or_reduce(clk_pulses));
+    dff_clk_exhausted_q: capi_rise_dff PORT MAP (
+         dout => clk_exhausted_q,
+         din => clk_exhausted,
+         clk   => psl_clk
+    );
+    dff_clk_exhausted_qq: capi_rise_dff PORT MAP (
+         dout => clk_exhausted_qq,
+         din => clk_exhausted_q,
+         clk   => psl_clk
+    );
+    dff_clk_exhausted_qqq: capi_rise_dff PORT MAP (
+         dout => clk_exhausted_qqq,
+         din => clk_exhausted_qq,
+         clk   => psl_clk
+    );
+    dff_clk_exhausted_qqqq: capi_rise_dff PORT MAP (
+         dout => clk_exhausted_qqqq,
+         din => clk_exhausted_qqq,
+         clk   => psl_clk
+    );
+
+    run_spi_clk <= dsm_s0x03 or dsm_s0x05 or dsm_s0x07;
+    spi_clk_tristate_n <= '0';
+    spi_clk_d <= '1' when (run_spi_clk = '0') else
+                  not(spi_clk_q) when ((read_speed = '0') and (cycdly_q(15) = '0') and (clk_exhausted = '0')) else
+                  not(spi_clk_q) when ((read_speed = '1') and (cycdly_q(14) = '0') and (cycdly_q(15) = '0') and  (clk_exhausted = '0')) else
+                  spi_clk_q;
+    dff_spi_clk_q: capi_rise_dff_init1 PORT MAP (
+         dout => spi_clk_q,
+         din => spi_clk_d,
+         clk   => psl_clk
+    );
+
+    dff_spi_clk: capi_rise_dff_init1 PORT MAP (
+         dout => spi_clk_int,
+         din => spi_clk_q,
+         clk   => psl_clk
+    );
+    dff_spi_clk_qq: capi_rise_dff_init1 PORT MAP (
+         dout => spi_clk_qq,
+         din => spi_clk_int,
+         clk   => psl_clk
+    );
+    spi_clk <= spi_clk_int;
+
+    --Chip Select
+    spi_cs_d <= '0' when ((dsm_s0x02 = '1') or (dsm_s0x03 = '1') or (dsm_s0x04 = '1') or
+                    (dsm_s0x05 = '1') or (dsm_s0x06 = '1') or (dsm_s0x07 = '1')) else
+                '1';
+
+    dff_spi_cs_q: capi_rise_dff_init1 PORT MAP (
+         dout => spi_cs_q,
+         din => spi_cs_d,
+         clk   => psl_clk
+    );
+
+    dff_spi_cs: capi_rise_dff_init1 PORT MAP (
+         dout => spi_cen,
+         din => spi_cs_q,
+         clk   => psl_clk
+    );
+
+ -- -- End Section -- --
+
+ -- ----------------------------------- --
+ -- Write FIFO                  --
+ -- ----------------------------------- --
+
+    fifo_reset <= msm_s0x00;
+    --Fifo write Side
+    pgm_fifo_push <= (not(pgm_fifo_full) and f_program_data_val);
+    pgm_data_mux_d <= "00" when (msm_s0x01 = '1') else (std_logic_vector(unsigned(pgm_data_mux_q) + 1));
+    pgm_data_mux_en <= pgm_fifo_push or msm_s0x01;
+    dff_program_data_mux: capi_en_rise_vdff GENERIC MAP ( width => 2 ) PORT MAP (
+         dout => pgm_data_mux_q,
+         en =>  pgm_data_mux_en,
+         din => pgm_data_mux_d,
+         clk   => psl_clk
+    );
+    pgm_fifo_wrdata <= f_program_data(24 to 31) when (pgm_data_mux_q = "00") else
+                       f_program_data(16 to 23) when (pgm_data_mux_q = "01") else
+                       f_program_data(8 to 15) when (pgm_data_mux_q = "10") else
+                       f_program_data(0 to 7);
+
+    f_program_data_ack <= '1' when ((pgm_fifo_push = '1') and (pgm_data_mux_q = "11")) else '0';
+    pgm_data_fifo: ENTITY work.capi_fifo
+      GENERIC MAP (DATA_WIDTH => 8,
+                   ADDR_WIDTH => 9
+      )
+      PORT MAP (
+        clk => psl_clk,
+        reset => fifo_reset,
+        push => pgm_fifo_push,
+        wrdata => pgm_fifo_wrdata,
+        pull => pgm_fifo_pull,
+        rddata => pgm_fifo_rddata,
+        empty => pgm_fifo_empty,
+        full => pgm_fifo_full
+      );
+
+    --Entry Count
+    pgm_fifo_cnt_d <= "0000000000" when (msm_s0x00 = '1') else
+                     std_logic_vector(unsigned(pgm_fifo_cnt) + 1) when ((pgm_fifo_push = '1') and (pgm_fifo_pull = '0')) else
+                     std_logic_vector(unsigned(pgm_fifo_cnt) - 1) when ((pgm_fifo_push = '0') and (pgm_fifo_pull = '1')) else
+                     pgm_fifo_cnt;
+    dff_pgm_fifo_cnt: capi_rise_vdff GENERIC MAP ( width => 10 ) PORT MAP (
+         dout => pgm_fifo_cnt,
+         din => pgm_fifo_cnt_d,
+         clk   => psl_clk
+    );
+    txfifo_has_256B <= or_reduce(pgm_fifo_cnt(0 to 1));
+
+      --Fifo read side
+
+     pgm_fifo_pull <= dsm_s0x06 and not(read_speed) and not(pgm_fifo_empty);
+     data <= pgm_fifo_rddata;
+ -- ----------------------------------- --
+ -- Read FIFO                  --
+ -- ----------------------------------- --
+
+   --Fifo write side
+   rd_fifo_push <= '1' when ((clk_exhausted = '1') and (clk_exhausted_q = '1') and (clk_exhausted_qq = '1') and (clk_exhausted_qqq = '1') and (dsm_s0x07 = '1') and (command = qspi_4B_read) and (rd_fifo_full = '0')) else '0';
+   rd_fifo_wrdata <= in_byte;
+
+  read_data_fifo: ENTITY work.capi_fifo
+    GENERIC MAP (DATA_WIDTH => 8,
+                 ADDR_WIDTH => 9
+    )
+    PORT MAP (
+      clk => psl_clk,
+      reset => fifo_reset,
+      push => rd_fifo_push,
+      wrdata => rd_fifo_wrdata,
+      pull => rd_fifo_pull,
+      rddata => rd_fifo_rddata,
+      empty => rd_fifo_empty,
+      full => rd_fifo_full
+    );
+
+    --Entry Count
+    rd_fifo_cnt_d <= "0000000000" when (msm_s0x00 = '1') else
+                     std_logic_vector(unsigned(rd_fifo_cnt) + 1) when ((rd_fifo_push = '1') and (rd_fifo_pull = '0')) else
+                     std_logic_vector(unsigned(rd_fifo_cnt) - 1) when ((rd_fifo_push = '0') and (rd_fifo_pull = '1')) else
+                     rd_fifo_cnt;
+    dff_rd_fifo_cnt: capi_rise_vdff GENERIC MAP ( width => 10 ) PORT MAP (
+         dout => rd_fifo_cnt,
+         din =>  rd_fifo_cnt_d,
+         clk   => psl_clk
+    );
+    rxfifo_rec_256B <= not(or_reduce(rd_fifo_cnt(0 to 1)));
+    rxfifo_has_4B <= or_reduce(rd_fifo_cnt(0 to 7));
+
+    --Fifo read side
+
+    start_4B_xfer_d <= '0' when (f_read_data_ack = '1') else '1';
+    start_4B_xfer_en <= (rxfifo_has_4B and not(f_read_data_val_q) and not(rd_fifo_pull)) or f_read_data_ack;
+    dff_start_4B_xfer: capi_en_rise_dff PORT MAP (
+         dout => start_4B_xfer,
+         en  => start_4B_xfer_en,
+         din =>  start_4B_xfer_d,
+         clk   => psl_clk
+    );
+
+    dff_start_4B_xfer_q: capi_rise_dff PORT MAP (
+         dout => start_4B_xfer_q,
+         din =>  start_4B_xfer,
+         clk   => psl_clk
+    );
+
+    rd_pull4B <= start_4B_xfer and not (start_4B_xfer_q);
+    dff_rd_pull4B_q: capi_rise_dff PORT MAP (
+         dout => rd_pull4B_q,
+         din =>  rd_pull4B,
+         clk   => psl_clk
+    );
+    dff_rd_pull4B_q2: capi_rise_dff PORT MAP (
+         dout => rd_pull4B_q2,
+         din =>  rd_pull4B_q,
+         clk   => psl_clk
+    );
+    dff_rd_pull4B_q3: capi_rise_dff PORT MAP (
+         dout => rd_pull4B_q3,
+         din =>  rd_pull4B_q2,
+         clk   => psl_clk
+    );
+    dff_rd_pull4B_q4: capi_rise_dff PORT MAP (
+         dout => rd_pull4B_q4,
+         din =>  rd_pull4B_q3,
+         clk   => psl_clk
+    );
+    rd_fifo_pull <= (not(rd_fifo_empty) and (rd_pull4B or rd_pull4B_q or rd_pull4B_q2 or rd_pull4B_q3));
+    dff_rd_fifo_pull: capi_rise_dff PORT MAP (
+         dout => rd_fifo_pull_q,
+         din =>  rd_fifo_pull,
+         clk   => psl_clk
+    );
+    f_read_data_d(0 to 7) <= rd_fifo_rddata when (rd_pull4B_q4 = '1') else f_read_data_q(0 to 7);
+    f_read_data_d(8 to 15) <= rd_fifo_rddata when (rd_pull4B_q3 = '1') else f_read_data_q(8 to 15);
+    f_read_data_d(16 to 23) <= rd_fifo_rddata when (rd_pull4B_q2 = '1') else f_read_data_q(16 to 23);
+    f_read_data_d(24 to 31) <= rd_fifo_rddata when (rd_pull4B_q = '1') else f_read_data_q(24 to 31);
+    dff_f_read_data: capi_en_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => f_read_data_q,
+         en =>  rd_fifo_pull_q,
+         din => f_read_data_d,
+         clk   => psl_clk
+    );
+    f_read_data_val_d <= '0' when ((f_read_data_ack = '1') or (msm_s0x00 = '1')) else '1';
+    update_frval <= f_read_data_ack or msm_s0x00 or (rd_pull4B_q4);
+    dff_f_read_data_val_q: capi_en_rise_dff PORT MAP (
+         dout => f_read_data_val_q,
+         en =>  update_frval,
+         din => f_read_data_val_d,
+         clk   => psl_clk
+    );
+    f_read_data <= f_read_data_q;
+    f_read_data_val <= f_read_data_val_q;
+
+END capi_flash_spi_mt25qt;

--- a/U200/src/capi_vsec.vhdl
+++ b/U200/src/capi_vsec.vhdl
@@ -1,0 +1,1381 @@
+-- *!***************************************************************************
+-- *! Copyright 2014-2018 International Business Machines
+-- *!
+-- *! Licensed under the Apache License, Version 2.0 (the "License");
+-- *! you may not use this file except in compliance with the License.
+-- *! You may obtain a copy of the License at
+-- *!
+-- *!     http://www.apache.org/licenses/LICENSE-2.0
+-- *!
+-- *! Unless required by applicable law or agreed to in writing, software
+-- *! distributed under the License is distributed on an "AS IS" BASIS,
+-- *! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- *! See the License for the specific language governing permissions and
+-- *! limitations under the License.
+-- *!
+-- *!***************************************************************************
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+ENTITY capi_vsec IS
+  PORT(psl_clk: in std_logic;
+    cfg_ext_read_received : IN STD_LOGIC;
+    cfg_ext_write_received : IN STD_LOGIC;
+    cfg_ext_register_number : IN STD_LOGIC_VECTOR(9 DOWNTO 0);
+    cfg_ext_function_number : IN STD_LOGIC_VECTOR(7 DOWNTO 0);
+    cfg_ext_write_data : IN STD_LOGIC_VECTOR(31 DOWNTO 0);
+    cfg_ext_write_byte_enable : IN STD_LOGIC_VECTOR(3 DOWNTO 0);
+    cfg_ext_read_data : OUT STD_LOGIC_VECTOR(31 DOWNTO 0);
+    cfg_ext_read_data_valid : OUT STD_LOGIC;
+
+       -- --------------- --
+       hi2c_cmdval: out std_logic;
+       hi2c_dataval: out std_logic;
+       hi2c_addr: out std_logic_vector(0 to 6);
+       hi2c_rd: out std_logic;
+       hi2c_cmdin: out std_logic_vector(0 to 7);
+       hi2c_datain: out std_logic_vector(0 to 7);
+       hi2c_blk: out std_logic;
+       hi2c_bytecnt: out std_logic_vector(0 to 7);
+       hi2c_cntlrsel: out std_logic_vector(0 to 2);
+       i2ch_wrdatack: in std_logic;
+       i2ch_dataval: in std_logic;
+       i2ch_error: in std_logic;
+       i2ch_dataout: in std_logic_vector(0 to 7);
+       i2ch_ready: in std_logic;
+
+       -- -------------- --
+       pci_pi_nperst0: in std_logic;
+       cpld_usergolden: in std_logic;
+       cpld_softreconfigreq: out std_logic;
+       cpld_user_bs_req: out std_logic;
+       cpld_oe: out std_logic;
+
+       -- --------------- --
+       f_program_req: out std_logic;                                        -- Level --
+       f_num_blocks: out std_logic_vector(0 to 15);                          -- 128KB Block Size --
+       f_start_blk: out std_logic_vector(0 to 9);
+       f_program_data: out std_logic_vector(0 to 31);
+       f_program_data_val: out std_logic;
+       f_program_data_ack: in std_logic;
+       f_ready: in std_logic;
+       f_done: in std_logic;
+       f_stat_erase: in std_logic;
+       f_stat_program: in std_logic;
+       f_stat_read: in std_logic;
+       f_remainder: in std_logic_vector(0 to 9);
+       f_states: in std_logic_vector(0 to 31);
+       f_memstat: in std_logic_vector(0 to 15);
+       f_memstat_past: in std_logic_vector(0 to 15);
+
+       -- -------------- --
+       f_read_req: out std_logic;
+       f_num_words_m1: out std_logic_vector(0 to 15);                        -- N-1 words --
+       f_read_start_addr: out std_logic_vector(0 to 31);
+       f_read_data: in std_logic_vector(0 to 31);
+       f_read_data_val: in std_logic;
+       f_read_data_ack: out std_logic;
+
+       i2cacc_wren: out std_logic;
+       i2cacc_data: out std_logic_vector(0 to 63);
+       i2cacc_rden: out std_logic;
+       i2cacc_rddata: in std_logic_vector(0 to 63);
+
+       -- -------------- -- PRF vectors
+       prf_wr_overall_ticks_data: in std_logic_vector(0 to 127);
+       prf_wr_overall_samples_data: in std_logic_vector(0 to 63);
+       prf_rd_overall_ticks_data: in std_logic_vector(0 to 127);
+       prf_rd_overall_samples_data: in std_logic_vector(0 to 63);
+       prf_rd_max_lat_dynamic_avg:in std_logic_vector(0 to 31);
+       prf_rd_dynamic_bw:in std_logic_vector(0 to 31);  -- NEW
+       prf_wr_dynamic_bw:in std_logic_vector(0 to 31);  -- NEW
+       prf_rd_max_lat: in std_logic_vector(0 to 31));
+
+END capi_vsec;
+
+ARCHITECTURE capi_vsec OF capi_vsec IS
+
+Component capi_rise_dff
+  PORT (clk   : in std_logic;
+        dout  : out std_logic;
+        din   : in std_logic);
+End Component capi_rise_dff;
+
+Component capi_rise_vdff
+  GENERIC ( width : positive );
+  PORT (clk   : in std_logic;
+        dout  : out std_logic_vector(0 to width-1);
+        din   : in std_logic_vector(0 to width-1));
+End Component capi_rise_vdff;
+
+Component capi_pgen32
+  PORT(parity: out std_logic_vector(0 to 3);
+       datain: in std_logic_vector(0 to 31));
+End Component capi_pgen32;
+
+Component capi_en_rise_vdff
+  GENERIC ( width : positive );
+  PORT (clk   : in std_logic;
+        en    : in std_logic;
+        dout  : out std_logic_vector(0 to width-1);
+        din   : in std_logic_vector(0 to width-1));
+End Component capi_en_rise_vdff;
+
+Component capi_sreconfig
+  PORT(psl_clk: in std_logic;
+
+       -- -------------- --
+       pci_pi_nperst0: in std_logic;
+       cpld_softreconfigreq: out std_logic;
+       cpld_user_bs_req: out std_logic;
+       cpld_oe: out std_logic;
+
+       -- -------------- --
+       req_reconfig: in std_logic;
+       req_user: in std_logic);
+End Component capi_sreconfig;
+
+Component capi_en_rise_dff
+  PORT (clk   : in std_logic;
+        en    : in std_logic;
+        dout  : out std_logic;
+        din   : in std_logic);
+End Component capi_en_rise_dff;
+
+Component capi_rise_vdff_init1
+  GENERIC ( width : positive );
+  PORT (clk   : in std_logic;
+        dout  : out std_logic_vector(0 to width-1);
+        din   : in std_logic_vector(0 to width-1));
+End Component capi_rise_vdff_init1;
+
+Component capi_en_rise_vdff_init1
+  GENERIC ( width : positive );
+  PORT (clk   : in std_logic;
+        dout  : out std_logic_vector(0 to width-1);
+        en    : in std_logic;
+        din   : in std_logic_vector(0 to width-1));
+End Component capi_en_rise_vdff_init1;
+
+function gate_and (gate : std_logic; din : std_logic_vector) return std_logic_vector is
+begin
+  if (gate = '1') then
+    return din;
+  else
+    return (0 to din'length-1 => '0');
+  end if;
+end gate_and;
+
+Signal cseb_addr_l: std_logic_vector(0 to 32);  -- v33bit
+Signal cseb_addr_parity_l: std_logic_vector(0 to 4);  -- v5bit
+Signal cseb_be_l: std_logic_vector(0 to 3);  -- v4bit
+Signal cseb_rddata_in: std_logic_vector(0 to 31);  -- v32bit
+Signal cseb_rddata_parity_in: std_logic_vector(0 to 3);  -- v4bit
+Signal cseb_rden_l_sig: std_logic;  -- bool
+Signal cseb_rdresponse_d: std_logic_vector(0 to 4);  -- v5bit
+Signal cseb_wrdata_l: std_logic_vector(0 to 31);  -- v32bit
+Signal cseb_wrdata_parity_l: std_logic_vector(0 to 3);  -- v4bit
+Signal cseb_wren_l: std_logic;  -- bool
+Signal cseb_wrresp_req_l: std_logic;  -- bool
+Signal cseb_wrresp_valid_in: std_logic;  -- bool
+Signal cseb_wrresponse_d: std_logic_vector(0 to 4);  -- v5bit
+
+Signal cfg_ext_read_received_valid: std_logic;
+Signal cfg_ext_write_received_i: std_logic;
+Signal    cseb_addr									: std_logic_vector(0 to 32);  		-- v33bit
+Signal    cseb_be                                        : std_logic_vector(0 to 3);          -- v4bit
+
+Signal f_program_data_val_d: std_logic;  -- bool
+Signal flash_rd_req: std_logic;  -- bool
+Signal image_loaded: std_logic;  -- bool
+Signal nafu_en: std_logic;  -- bool
+Signal num_afus_d: std_logic_vector(0 to 3);  -- v4bit
+Signal num_afus_enabled: std_logic_vector(0 to 3);  -- v4bit
+Signal num_afus_lsb: std_logic;  -- bool
+Signal num_afus_msbs: std_logic_vector(0 to 2);  -- v3bit
+Signal nxt_cap_id: std_logic_vector(0 to 15);  -- v16bit
+Signal one_afu_reset: std_logic;  -- bool
+-- Signal rden_pulse: std_logic;  -- bool
+Signal rden_pulse_in: std_logic;  -- bool
+Signal reconfig_cntl_d: std_logic_vector(0 to 1);  -- v2bit
+Signal reconfig_cntl_q: std_logic_vector(0 to 1);  -- v2bit
+Signal req_reconfig: std_logic;  -- bool
+Signal req_user: std_logic;  -- bool
+Signal sreconfig_en: std_logic;  -- bool
+Signal sreconfig_rdat2: std_logic;  -- bool
+Signal sreconfig_rdat3: std_logic;  -- bool
+Signal sreconfig_wdat2: std_logic;  -- bool
+Signal sreconfig_wdat3: std_logic;  -- bool
+Signal sreconfig_wrdat: std_logic_vector(0 to 1);  -- v2bit
+Signal v10const: std_logic_vector(0 to 27);  -- v28bit
+Signal v8const: std_logic_vector(0 to 27);  -- v28bit
+--Signal version: std_logic_vector(0 to 31);  -- int
+Signal vfadr_en: std_logic;  -- bool
+Signal vfctl_en: std_logic;  -- bool
+Signal vfppc_en: std_logic;  -- bool
+Signal vfppp_en: std_logic;  -- bool
+signal vfi2c_lo_en: std_logic;
+signal vfi2c_hi_en: std_logic;
+Signal vfrddp_en: std_logic;  -- bool
+Signal vfrddp_read: std_logic;  -- bool
+Signal vfrddp_val: std_logic;  -- bool
+Signal vfrddp_val_d: std_logic;  -- bool
+Signal vfsize_en: std_logic;  -- bool
+Signal vfwrdp_en: std_logic;  -- bool
+Signal vpd40data: std_logic_vector(0 to 31);  -- v32bit
+Signal vpd44data: std_logic_vector(0 to 31);  -- v32bit
+Signal vpd44data_d: std_logic_vector(0 to 31);  -- v32bit
+Signal vpd44data_q: std_logic_vector(0 to 31);  -- v32bit
+Signal vpd44_update: std_logic;
+Signal vpd44data_be: std_logic_vector(0 to 31); -- v32bit
+Signal vpd_usehardcoded: std_logic;  -- bool
+signal vpd_debug_flag: std_logic;
+Signal vpd_0x40: std_logic;  -- bool
+Signal vpd_0x44: std_logic;  -- bool
+Signal vpd_base: std_logic;  -- bool
+Signal vpd_rdy_flag: std_logic;  -- bool
+Signal vpd_rdy_flag_d: std_logic;  -- bool
+Signal vpd_rdy_flag_q: std_logic;  -- bool
+Signal update_vpd_rdy_flag: std_logic;  -- bool
+Signal vpd_read_done_d: std_logic;
+Signal vpd_read_done_q: std_logic;
+Signal vpd_write_done_d: std_logic;
+Signal vpd_write_done_q: std_logic;
+Signal vpdadr: std_logic_vector(0 to 5);  -- v5bit
+Signal vsec10data: std_logic_vector(0 to 31);  -- v32bit
+Signal vsec40data: std_logic_vector(0 to 31);  -- v32bit
+Signal vsec44data: std_logic_vector(0 to 31);  -- v32bit
+Signal vsec50data: std_logic_vector(0 to 31);  -- v32bit
+Signal vsec54data: std_logic_vector(0 to 31);  -- v32bit
+Signal vsec58data: std_logic_vector(0 to 31);  -- v32bit
+Signal vsec5C_reg_en: std_logic;  -- bool
+Signal vsec5Cdata: std_logic_vector(0 to 31);  -- v32bit
+Signal vsec5Cdata_d: std_logic_vector(0 to 31);  -- v32bit
+Signal vsec8data: std_logic_vector(0 to 31);  -- v32bit
+Signal vsecCdata: std_logic_vector(0 to 31);  -- v32bit
+Signal vsec_0x00: std_logic;  -- bool
+Signal vsec_0x04: std_logic;  -- bool
+Signal vsec_0x08: std_logic;  -- bool
+Signal vsec_0x0C: std_logic;  -- bool
+Signal vsec_0x10: std_logic;  -- bool
+Signal vsec_0x20: std_logic;  -- bool
+Signal vsec_0x24: std_logic;  -- bool
+Signal vsec_0x28: std_logic;  -- bool
+Signal vsec_0x2C: std_logic;  -- bool
+Signal vsec_0x40: std_logic;  -- bool
+Signal vsec_0x44: std_logic;  -- bool
+Signal vsec_0x50: std_logic;  -- bool
+Signal vsec_0x54: std_logic;  -- bool
+Signal vsec_0x58: std_logic;  -- bool
+Signal vsec_0x5C: std_logic;  -- bool
+Signal vsec_addr: std_logic_vector(0 to 32);  -- v33bit
+Signal vsec_base: std_logic;  -- bool
+Signal vsec_fadr: std_logic_vector(0 to 31);  -- v32bit
+Signal vsec_fsize: std_logic_vector(0 to 15);  -- v16bit
+Signal vsec_rddata: std_logic_vector(0 to 31);  -- v32bit
+Signal vsec_wrdata: std_logic_vector(0 to 31);  -- v32bit
+Signal vvpdadr_en: std_logic;  -- bool
+Signal vvpdadr_en_q1: std_logic; -- bool
+Signal vvpdadr_en_q2: std_logic; -- bool
+Signal vvpdadr_en_q3: std_logic; -- bool
+Signal vvpdadr_en_q4: std_logic; -- bool
+Signal vvpdadr_en_q5: std_logic; -- bool
+Signal vvpdwrdat_en: std_logic;  -- bool
+-- Signal waitrequest: std_logic;  -- bool
+-- Signal waitrequest_in: std_logic;  -- bool
+-- Signal waitrequest_rst_sig: std_logic;  -- bool
+-- Signal wren_pulse: std_logic;  -- bool
+Signal wren_pulse_in: std_logic;  -- bool
+Signal xilinxvsecCdata: std_logic_vector(0 to 31);  -- v32bit
+-- Signal cseb_waitrequestinternal: std_logic;  -- bool
+Signal f_program_data_valinternal: std_logic;  -- bool
+Signal f_program_reqinternal: std_logic;  -- bool
+Signal f_read_reqinternal: std_logic;  -- bool
+Signal hi2c_cmdval_d: std_logic;
+Signal hi2c_dataval_d: std_logic;
+Signal hi2c_rd_d: std_logic;
+Signal hi2c_cmdin_d: std_logic_vector(0 to 7);
+Signal hi2c_datain_d: std_logic_vector(0 to 7);
+Signal i2ch_ready_d: std_logic;
+Signal hi2c_cmdval_q: std_logic;
+Signal hi2c_cmdval_q1: std_logic;
+Signal hi2c_cmdval_q2: std_logic;
+Signal hi2c_cmdval_q3: std_logic;
+Signal hi2c_cmdval_q4: std_logic;
+Signal hi2c_cmdval_q5: std_logic;
+Signal hi2c_dataval_q: std_logic;
+Signal hi2c_rd_q: std_logic;
+Signal hi2c_cmdin_q: std_logic_vector(0 to 7);
+Signal hi2c_datain_q: std_logic_vector(0 to 7);
+Signal i2ch_ready_q: std_logic;
+Signal i2c_byteop_d: std_logic_vector(0 to 2);
+Signal i2c_byteop_q: std_logic_vector(0 to 2);
+Signal i2c_monitor_ready_d: std_logic;
+Signal i2c_monitor_ready_q: std_logic;
+Signal vpdwrdat: std_logic_vector(0 to 31);
+Signal eeprom_wdelay_count_d: std_logic_vector(0 to 20);
+Signal eeprom_wdelay_count_q: std_logic_vector(0 to 20);
+Signal fiveCfull: std_logic;
+Signal fiveCfull_d: std_logic;
+Signal f_read_data_ack_int: std_logic;
+
+attribute mark_debug : string;
+
+-- New signals for Performance Measurement Logic
+Signal vsec_0x14: std_logic;  -- bool
+Signal vsec_0x18: std_logic;  -- bool
+Signal vsec_0x1C: std_logic;  -- bool
+Signal vsec_0x30: std_logic;  -- bool
+Signal vsec_0x34: std_logic;  -- bool
+Signal vsec_0x38: std_logic;  -- bool
+Signal vsec_0x3C: std_logic;  -- bool
+Signal vsec_0x48: std_logic;  -- bool
+Signal vsec_0x4C: std_logic;  -- bool
+Signal vsec_0x60: std_logic;  -- bool
+Signal vsec_0x64: std_logic;  -- bool
+Signal vsec_0x68: std_logic;  -- bool
+Signal vsec_0x6c: std_logic;  -- bool
+Signal vsec_0x70: std_logic;  -- bool
+Signal vsec_0x74: std_logic;  -- bool
+Signal vsec_0x78: std_logic;  -- bool
+Signal prf_32_0_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_1_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_2_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_3_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_4_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_5_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_6_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_7_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_8_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_9_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_10_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_11_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_12_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_13_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_14_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_15_bits_of_prf_data: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_0_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_1_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_2_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_3_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_4_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_5_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_6_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_7_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_8_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_9_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_10_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_11_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_12_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_13_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_14_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_15_bits_of_prf_data_l1: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_0_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_1_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_2_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_3_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_4_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_5_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_6_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_7_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_8_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_9_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_10_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_11_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_12_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_13_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_14_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+Signal prf_32_15_bits_of_prf_data_l2: std_logic_vector(0 to 31);  -- v32bit
+
+begin
+
+
+--    version <= "00000000000000000000000000010101" ;
+
+--============================================================================================
+---- Misc. Logic
+--==============================================================================================--
+ -- ----------------------------------- --
+ -- Interface Control                   --
+ -- ----------------------------------- --
+
+    dff_prf_32_0_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_0_bits_of_prf_data_l1,
+                din     => prf_32_0_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_1_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_1_bits_of_prf_data_l1,
+                din     => prf_32_1_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_2_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_2_bits_of_prf_data_l1,
+                din     => prf_32_2_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_3_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_3_bits_of_prf_data_l1,
+                din     => prf_32_3_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_4_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_4_bits_of_prf_data_l1,
+                din     => prf_32_4_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_5_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_5_bits_of_prf_data_l1,
+                din     => prf_32_5_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_6_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_6_bits_of_prf_data_l1,
+                din     => prf_32_6_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_7_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_7_bits_of_prf_data_l1,
+                din     => prf_32_7_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_8_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_8_bits_of_prf_data_l1,
+                din     => prf_32_8_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_9_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_9_bits_of_prf_data_l1,
+                din     => prf_32_9_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_10_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_10_bits_of_prf_data_l1,
+                din     => prf_32_10_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_11_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_11_bits_of_prf_data_l1,
+                din     => prf_32_11_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_12_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_12_bits_of_prf_data_l1,
+                din     => prf_32_12_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_13_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_13_bits_of_prf_data_l1,
+                din     => prf_32_13_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_14_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_14_bits_of_prf_data_l1,
+                din     => prf_32_14_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_15_l1: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_15_bits_of_prf_data_l1,
+                din     => prf_32_15_bits_of_prf_data,
+        clk     => psl_clk
+    );
+
+
+    dff_prf_32_0_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_0_bits_of_prf_data_l2,
+                din     => prf_32_0_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_1_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_1_bits_of_prf_data_l2,
+                din     => prf_32_1_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_2_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_2_bits_of_prf_data_l2,
+                din     => prf_32_2_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_3_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_3_bits_of_prf_data_l2,
+                din     => prf_32_3_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_4_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_4_bits_of_prf_data_l2,
+                din     => prf_32_4_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_5_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_5_bits_of_prf_data_l2,
+                din     => prf_32_5_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_6_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_6_bits_of_prf_data_l2,
+                din     => prf_32_6_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_7_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_7_bits_of_prf_data_l2,
+                din     => prf_32_7_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_8_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_8_bits_of_prf_data_l2,
+                din     => prf_32_8_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_9_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_9_bits_of_prf_data_l2,
+                din     => prf_32_9_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_10_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_10_bits_of_prf_data_l2,
+                din     => prf_32_10_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_11_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_11_bits_of_prf_data_l2,
+                din     => prf_32_11_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_12_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_12_bits_of_prf_data_l2,
+                din     => prf_32_12_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_13_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_13_bits_of_prf_data_l2,
+                din     => prf_32_13_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_14_l2: capi_rise_vdff  GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_14_bits_of_prf_data_l2,
+                din     => prf_32_14_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+    dff_prf_32_15_l2: capi_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+                dout    => prf_32_15_bits_of_prf_data_l2,
+                din     => prf_32_15_bits_of_prf_data_l1,
+        clk     => psl_clk
+    );
+
+
+    cseb_wrresponse_d <= "00000" ;
+    cseb_rdresponse_d <= "00000" ;
+
+    cfg_ext_read_data_valid           <= cseb_rden_l_sig;
+
+
+    --read data enable - byte offset 0x400 for vsec and 0xB0 for vpd
+      --  decode regno>=0x100 or (regno>=0x2C and regno < 0x40)
+      cfg_ext_read_received_valid <= '1' when ((cfg_ext_read_received = '1') and
+                                               ((cfg_ext_register_number(9 downto 8) /= "00") or
+                                               ((cfg_ext_register_number(9 downto 0) >= "0000101100") and (cfg_ext_register_number(9 downto 0) < "0001000000")))) else '0';
+
+ -- Latch Inputs                        --
+    dff_cseb_rden_l: capi_rise_dff PORT MAP (
+         dout => cseb_rden_l_sig,
+         din => cfg_ext_read_received_valid,
+         clk   => psl_clk
+    );
+
+  cfg_ext_write_received_i  <=  '1' when ((cfg_ext_write_received = '1') and
+                                           ((cfg_ext_register_number(9 downto 8) /= "00") or
+                                           ((cfg_ext_register_number(9 downto 0) >= "0000101100") and (cfg_ext_register_number(9 downto 0) < "0001000000")))) else '0';
+
+    dff_cseb_wren_l: capi_rise_dff PORT MAP (
+         dout => cseb_wren_l,
+         din => cfg_ext_write_received_i,
+         clk   => psl_clk
+    );
+
+    dff_cseb_wrresp_req_l: capi_rise_dff PORT MAP (
+         dout => cseb_wrresp_req_l,
+         din => '0',
+         clk   => psl_clk
+    );
+
+
+-- address and  Byte enables
+      cseb_addr(21 to 30)       <=   cfg_ext_register_number;
+      cseb_addr(0 to 20)        <=   "000000000000000000000";
+      cseb_addr(31 to 32)       <=   "00";
+      cseb_be                   <=   cfg_ext_write_byte_enable;
+
+    dff_cseb_addr_l: capi_rise_vdff GENERIC MAP ( width => 33 ) PORT MAP (
+         dout => cseb_addr_l,
+         din => cseb_addr,
+         clk   => psl_clk
+    );
+
+    dff_cseb_addr_parity_l: capi_rise_vdff GENERIC MAP ( width => 5 ) PORT MAP (
+         dout => cseb_addr_parity_l,
+         din => "00000",
+         clk   => psl_clk
+    );
+
+    dff_cseb_be_l: capi_rise_vdff GENERIC MAP ( width => 4 ) PORT MAP (
+         dout => cseb_be_l,
+         din => cseb_be,
+         clk   => psl_clk
+    );
+
+    dff_cseb_wrdata_l: capi_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => cseb_wrdata_l,
+         din => cfg_ext_write_data,
+         clk   => psl_clk
+    );
+
+    dff_cseb_wrdata_parity_l: capi_rise_vdff GENERIC MAP ( width => 4 ) PORT MAP (
+         dout => cseb_wrdata_parity_l,
+         din => "0000",
+         clk   => psl_clk
+    );
+
+    wren_pulse_in <= cseb_wren_l ;
+    rden_pulse_in <= cseb_rden_l_sig;
+
+    dff_image_loaded: capi_rise_dff PORT MAP (
+         dout => image_loaded,
+         din => cpld_usergolden,
+         clk   => psl_clk
+    );
+    cfg_ext_read_data    <= cseb_rddata_in;
+    cseb_wrresp_valid_in <=  not (f_program_data_valinternal  and  cseb_wrresp_req_l  and  cseb_wren_l  and  vsec_0x5C) ;
+
+ -- -- End Section -- --
+
+--============================================================================================
+---- Read Mux
+--==============================================================================================--
+
+    vsec_rddata <= gate_and(vpd_0x40,vpd40data) or
+                   gate_and(vpd_0x44,vpd44data) or
+                   gate_and(vsec_0x00,"00000000000000010000000000001011") or
+                   gate_and(vsec_0x04,"00001000000000000001001010000000") or
+                   gate_and(vsec_0x08,vsec8data) or
+                   gate_and(vsec_0x0C,vsecCdata) or
+                   gate_and(vsec_0x10,vsec10data) or
+                   gate_and(vsec_0x20,"00000000000000000000000100000000") or
+                   gate_and(vsec_0x24,"00000000000000000000000001000000") or
+                   gate_and(vsec_0x28,"00000000000000000000001000000000") or
+                   gate_and(vsec_0x2C,"00000000000000000000010000000000") or
+                   gate_and(vsec_0x40,vsec40data) or
+                   gate_and(vsec_0x44,vsec44data) or
+                   gate_and(vsec_0x50,vsec50data) or
+                   gate_and(vsec_0x54,vsec54data) or
+                   gate_and(vsec_0x58,vsec58data) or
+--                   gate_and(vsec_0x14,prf_32_0_bits_of_prf_data_l2) or
+--                   gate_and(vsec_0x18,prf_32_1_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x18,i2cacc_rddata(32 to 63)) or
+                   gate_and(vsec_0x1C,i2cacc_rddata(0 to 31)) or
+--                   gate_and(vsec_0x1C,prf_32_2_bits_of_prf_data_l2) or
+ --                   gate_and(vsec_0x30,prf_32_3_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x34,prf_32_4_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x38,prf_32_5_bits_of_prf_data_l2) or
+ --                    gate_and(vsec_0x3C,prf_32_6_bits_of_prf_data_l2) or
+ --                   gate_and(vsec_0x48,prf_32_7_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x4C,prf_32_8_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x60,prf_32_9_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x64,prf_32_10_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x68,prf_32_11_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x6C,prf_32_12_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x70,prf_32_13_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x74,prf_32_14_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x78,prf_32_15_bits_of_prf_data_l2) or
+                   gate_and(vsec_0x5C,vsec5Cdata);
+
+
+
+    cseb_rddata_in <= vsec_rddata ;
+-- AM Feb26, 2017    pgen_cseb_rddata_parity_in: capi_pgen32
+-- AM Feb26, 2017. Currently parity is not in use
+-- AM Feb26, 2017      PORT MAP (
+-- AM Feb26, 2017         parity => cseb_rddata_parity_in,
+-- AM Feb26, 2017         datain => cseb_rddata_in
+-- AM Feb26, 2017    );
+
+--============================================================================================
+---- VSEC Registers
+--==============================================================================================--
+    vsec_wrdata <= cseb_wrdata_l ;
+
+ -- ----------------------------------- --
+ -- Number of AFUs VSEC Field           --
+ -- ----------------------------------- --
+-- In VU3P wren_pulse is active one cycle LATER THAN vsec_address and cseb_be_l signals
+-- AM Feb26, 2017    nafu_en <= vsec_0x08  and  cseb_be_l(3)  and  wren_pulse ;
+    nafu_en <= vsec_0x08  and  cseb_be_l(3)  and  wren_pulse_in ;
+
+    --mux(type=v4bit) (num_afus_d, capi_dl_done, num_afu_ports, vsec_wrdata[28..31]);--
+    one_afu_reset <=  not vsec_wrdata(31) ;
+    num_afus_d <= ( vsec_wrdata(28 to 30) & one_afu_reset );
+
+    endff_num_afus_enabled: capi_en_rise_vdff GENERIC MAP ( width => 4 ) PORT MAP (
+         dout => num_afus_enabled,
+         en => nafu_en,
+         din => num_afus_d,
+         clk   => psl_clk
+    );
+
+
+    v8const <= "0000000000100001000010000000" ;
+
+    num_afus_msbs <= num_afus_enabled(0 to 2) ;
+    num_afus_lsb <=  not num_afus_enabled(3) ;
+    vsec8data <= ( v8const & num_afus_msbs & num_afus_lsb );
+
+ -- -- End Section -- --
+
+ -- -------------------------------------- --
+ -- CAIA/PSL Version  --
+ -- -------------------------------------- --
+ -- xilinxvsecCdata <= "00000001000000000011000000000001" ;
+    xilinxvsecCdata <= "00000010000000000000000000000110" ;
+
+    vsecCdata <= xilinxvsecCdata ;
+ -- -------------------------------------- --
+ -- Soft Reconfiguration Status / Control  --
+ -- -------------------------------------- --
+ -- AM Feb27, 2017    sreconfig_en <= vsec_0x10  and  cseb_be_l(0)  and  wren_pulse ;
+    sreconfig_en <= vsec_0x10  and  cseb_be_l(0)  and  wren_pulse_in ;
+
+    sreconfig_wdat2 <=  not vsec_wrdata(2) ;
+    -- image_loaded: 0=factory 1=user.  If this is user image, invert bit 3
+    -- (aka bit 28 - image select) so that default is to reload same image
+    sreconfig_wdat3 <=  image_loaded xor vsec_wrdata(3) ;
+    sreconfig_wrdat <= ( sreconfig_wdat2 & sreconfig_wdat3 );
+
+    -- v2bit reconfig_cntl_d = vsec_wrdata.[2..3];
+    reconfig_cntl_d <= sreconfig_wrdat ;
+    endff_reconfig_cntl_q: capi_en_rise_vdff GENERIC MAP ( width => 2 ) PORT MAP (
+         dout => reconfig_cntl_q,
+         en => sreconfig_en,
+         din => reconfig_cntl_d,
+         clk   => psl_clk
+    );
+
+    v10const <= "0000000000000000000000000000" ;  -- Base Image Revision --
+
+    sreconfig_rdat2 <=  not reconfig_cntl_q(0) ;
+    sreconfig_rdat3 <=  image_loaded xor reconfig_cntl_q(1) ;
+    --concat(type=v32bit) (vsec10data, image_loaded, 0b0, reconfig_cntl_q, v10const);
+    vsec10data <= ( image_loaded & '0' & sreconfig_rdat2 & sreconfig_rdat3 & v10const );
+
+    req_reconfig <= vsec10data(2) ;
+    req_user <= vsec10data(3) ;
+
+    scfg: capi_sreconfig
+      PORT MAP (
+         pci_pi_nperst0 => pci_pi_nperst0,
+         cpld_softreconfigreq => cpld_softreconfigreq,
+         cpld_user_bs_req => cpld_user_bs_req,
+         cpld_oe => cpld_oe,
+         req_reconfig => req_reconfig,
+         req_user => req_user,
+         psl_clk => psl_clk
+    );
+
+ -- -- End Section -- --
+
+-- ----------------------------------- --
+ -- I2C interface                --
+ -- ----------------------------------- --
+    vfi2c_lo_en <= vsec_0x18  and  cseb_be_l(0)  and  cseb_be_l(2)  and
+                                cseb_be_l(1)  and  cseb_be_l(0)  and  wren_pulse_in ;
+    vfi2c_hi_en <= vsec_0x1C  and  cseb_be_l(0)  and  cseb_be_l(2)  and
+                                cseb_be_l(1)  and  cseb_be_l(0)  and  wren_pulse_in ;
+
+    i2cacc_wren <= vfi2c_hi_en;
+    i2cacc_rden <= vsec_0x1C and cseb_be_l(0)  and  cseb_be_l(2)  and
+                                cseb_be_l(1)  and  cseb_be_l(0)  and rden_pulse_in;
+
+    endff_vsec18data: capi_en_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => i2cacc_data(32 to 63),
+         en => vfi2c_lo_en,
+         din => vsec_wrdata,
+         clk   => psl_clk
+    );
+
+    endff_vsec1Cdata: capi_en_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => i2cacc_data(0 to 31),
+         en => vfi2c_hi_en,
+         din => vsec_wrdata,
+         clk   => psl_clk
+    );
+
+ -- -- End Section -- --
+
+ -- ----------------------------------- --
+ -- PSL Programming Port                --
+ -- ----------------------------------- --
+    vfppp_en <= vsec_0x40  and  cseb_be_l(0)  and  cseb_be_l(2)  and
+ -- AM Feb27, 2017                               cseb_be_l(1)  and  cseb_be_l(0)  and  wren_pulse ;
+                                cseb_be_l(1)  and  cseb_be_l(0)  and  wren_pulse_in ;
+
+    endff_vsec40data: capi_en_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => vsec40data,
+         en => vfppp_en,
+         din => vsec_wrdata,
+         clk   => psl_clk
+    );
+
+ -- -- End Section -- --
+
+-- ----------------------------------- --
+ -- AFU 2E2 PRF Vectors                --
+ -- ----------------------------------- --
+    prf_32_0_bits_of_prf_data <= prf_wr_overall_ticks_data(0 to 31) ;
+    prf_32_1_bits_of_prf_data <= prf_wr_overall_ticks_data(32 to 63) ;
+    prf_32_2_bits_of_prf_data <= prf_wr_overall_ticks_data(64 to 95) ;
+    prf_32_3_bits_of_prf_data <= prf_wr_overall_ticks_data(96 to 127) ;
+    prf_32_4_bits_of_prf_data <= prf_rd_overall_ticks_data(0 to 31) ;
+    prf_32_5_bits_of_prf_data <= prf_rd_overall_ticks_data(32 to 63) ;
+    prf_32_6_bits_of_prf_data <= prf_rd_overall_ticks_data(64 to 95) ;
+    prf_32_7_bits_of_prf_data <= prf_rd_overall_ticks_data(96 to 127) ;
+    prf_32_8_bits_of_prf_data <= prf_wr_overall_samples_data(0 to 31) ;
+    prf_32_9_bits_of_prf_data <= prf_wr_overall_samples_data(32 to 63) ;
+    prf_32_10_bits_of_prf_data <= prf_rd_overall_samples_data(0 to 31) ;
+    prf_32_11_bits_of_prf_data <= prf_rd_overall_samples_data(32 to 63) ;
+    prf_32_12_bits_of_prf_data <= prf_rd_max_lat(0 to 31) ;
+    prf_32_13_bits_of_prf_data <= prf_rd_max_lat_dynamic_avg(0 to 31) ;
+    prf_32_14_bits_of_prf_data <= prf_wr_dynamic_bw(0 to 31) ;
+    prf_32_15_bits_of_prf_data <= prf_rd_dynamic_bw(0 to 31) ;
+
+ -- ----------------------------------- --
+ -- PSL Programming Port                --
+ -- ----------------------------------- --
+ -- AM Feb27, 2017   vfppc_en <= vsec_0x44  and  cseb_be_l(0)  and  wren_pulse ;
+    vfppc_en <= vsec_0x44  and  cseb_be_l(0)  and  wren_pulse_in ;
+
+    endff_vsec44data: capi_en_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => vsec44data,
+         en => vfppc_en,
+         din => vsec_wrdata,
+         clk   => psl_clk
+    );
+
+ -- -- End Section -- --
+
+ -- ----------------------------------- --
+ -- VPD Address Register                --
+ -- ----------------------------------- --
+
+-- VPD Read Procedure:
+-- 1. Write vpd flag bit(0) and vpd addr field bits(1:15) at the same time. Bits 14:15 must be 0 to create dword aligned address. Write accomplished by pcie config write to legacy space address 0x40.
+-- 2. Hardware will always read out precisely 4 bytes from vpd storage unit per specification. In this impelemntation, 4 bytes are written via I2C. vpd flag bit will be set to 1 when transfer is complete.
+-- 3. Software polls vpd flag. When it sees the 1, it reads vpd data register at offset 0x44 for 4 bytes of vpd infromation. Operation is complete. Address and data fields may not be modified prior to flag being set.
+
+-- VPD Write Procedure:
+-- 1. Write 4 bytes of data to vpd data register (pci config offset 0x44)
+-- 2. Write vpd address field to desired 4 byte location and write vpd flag to a 1 at the same time.
+-- 3. Software monitors the vpd flag, and when set to 0, write operation is complete. Do not write to update vpd address or data fields before flag is reset to 0.
+
+    vvpdadr_en <= vpd_0x40  and  (cseb_be_l(3)  or  cseb_be_l(2)  or
+ -- AM Feb27, 2017                                cseb_be_l(1)  or  cseb_be_l(0))  and  wren_pulse ;
+                                 cseb_be_l(1)  or  cseb_be_l(0))  and  wren_pulse_in ;
+    dff_vvpdadr_en_q1: capi_rise_dff PORT MAP (
+         dout => vvpdadr_en_q1,
+         din => vvpdadr_en,
+         clk   => psl_clk
+    );
+    dff_vvpdadr_en_q2: capi_rise_dff PORT MAP (
+         dout => vvpdadr_en_q2,
+         din => vvpdadr_en_q1,
+         clk   => psl_clk
+    );
+    dff_vvpdadr_en_q3: capi_rise_dff PORT MAP (
+         dout => vvpdadr_en_q3,
+         din => vvpdadr_en_q2,
+         clk   => psl_clk
+    );
+    dff_vvpdadr_en_q4: capi_rise_dff PORT MAP (
+         dout => vvpdadr_en_q4,
+         din => vvpdadr_en_q3,
+         clk   => psl_clk
+    );
+    dff_vvpdadr_en_q5: capi_rise_dff PORT MAP (
+         dout => vvpdadr_en_q5,
+         din => vvpdadr_en_q4,
+         clk   => psl_clk
+    );
+
+    vvpdwrdat_en <= vpd_0x44  and  (cseb_be_l(3)  or  cseb_be_l(2)  or
+                                 cseb_be_l(1)  or  cseb_be_l(0))  and  wren_pulse_in ;
+
+   --Register to hold vpd write data
+    endff_vpdwrdat: capi_en_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => vpdwrdat,
+         en => vvpdwrdat_en,
+         din => vsec_wrdata,
+         clk   => psl_clk
+    );
+
+    endff_vpdadr: capi_en_rise_vdff GENERIC MAP ( width => 6 ) PORT MAP (
+         dout => vpdadr,
+         en => vvpdadr_en,
+         din => vsec_wrdata(8 to 13),
+         clk   => psl_clk
+    );
+
+   endff_vpd_debug_flag: capi_en_rise_dff PORT MAP (
+         dout => vpd_debug_flag,
+         en => vvpdadr_en,
+         din => vsec_wrdata(1),
+         clk   => psl_clk
+    );
+   vpd_usehardcoded <= not(vpd_debug_flag);
+
+   endff_vpd_rdy_flag: capi_en_rise_dff PORT MAP (
+         dout => vpd_rdy_flag_q,
+         en => update_vpd_rdy_flag,
+         din => vpd_rdy_flag_d,
+         clk   => psl_clk
+    );
+
+    update_vpd_rdy_flag <= '1' when ((vvpdadr_en = '1') or (vpd_read_done_d = '1' and vpd_read_done_q = '0') or (vpd_write_done_d = '1' and vpd_write_done_q = '0') or vpd_usehardcoded='1') else '0';
+    vpd_rdy_flag_d <= vsec_wrdata(0) when  (vvpdadr_en = '1') else
+                      '1' when ((vpd_read_done_d = '1' and vpd_read_done_q = '0')) else
+                      '0' when ((vpd_write_done_d = '1' and vpd_write_done_q = '0')) else
+                      vpd_rdy_flag_q;
+    vpd_rdy_flag <=  vpd_rdy_flag_q;
+
+    vpd_read_done_d <= '1' when ((i2ch_ready = '1') and (i2c_byteop_d = "100") and (i2c_byteop_q = "011") and (hi2c_rd_d = '1')) else
+                       '1' when ((vpd_usehardcoded = '1') and (vvpdadr_en_q3='1') and (hi2c_rd_d = '1')) else
+                       '0';
+    vpd_write_done_d <= '1' when ((i2ch_ready = '1') and (i2c_byteop_d = "100") and (i2c_byteop_q = "011") and (hi2c_rd_d = '0')) else
+                       '0' when ((vpd_usehardcoded = '1') and (vvpdadr_en_q3='1') and (hi2c_rd_d = '0')) else
+                       '0';
+    dff_vpd_read_done_q: capi_rise_dff PORT MAP (
+         dout => vpd_read_done_q,
+         din => vpd_read_done_d,
+         clk   => psl_clk
+    );
+    dff_vpd_write_done_q: capi_rise_dff PORT MAP (
+         dout => vpd_write_done_q,
+         din => vpd_write_done_d,
+         clk   => psl_clk
+    );
+    -- Ultrascale:  nxtcap=0x80  UltraScale+ - VPD is last PCI capability, nxtcap=0
+    nxt_cap_id <= "00000000" & "00000011" ;
+    --No need for rdy_flag, not being read from flash and the i2c controller automatically read in the data at power on.
+--pcie vpd structure: bit0 = vpd ready/valid, bits 1:15 = vpd addr, bits 16:23 = pointer to next ID (0x00), bits 24:31 = 0x03
+    vpd40data <= ( vpd_rdy_flag & "0000000" & vpdadr & "00" & nxt_cap_id );
+
+    --temp create sample vpd structure that is ready immediately
+    endff_vpd44data_q: capi_en_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => vpd44data_q,
+         en => vpd44_update,
+         din => vpd44data_d,
+         clk   => psl_clk
+    );
+    vpd44_update <= i2ch_dataval or vvpdwrdat_en;
+    vpd44data_d(24 to 31) <= vsec_wrdata(24 to 31) when (vvpdwrdat_en = '1') else i2ch_dataout when (i2c_byteop_d = "000") else vpd44data_q(24 to 31);
+    vpd44data_d(16 to 23) <= vsec_wrdata(16 to 23) when (vvpdwrdat_en = '1') else i2ch_dataout when (i2c_byteop_d = "001") else vpd44data_q(16 to 23);
+    vpd44data_d(8 to 15) <= vsec_wrdata(8 to 15) when (vvpdwrdat_en = '1') else i2ch_dataout when (i2c_byteop_d = "010") else vpd44data_q(8 to 15);
+    vpd44data_d(0 to 7) <= vsec_wrdata(0 to 7) when (vvpdwrdat_en = '1') else i2ch_dataout when (i2c_byteop_d = "011") else vpd44data_q(0 to 7);
+
+    vpd44data <= vpd44data_q when (vpd_usehardcoded = '0') else vpd44data_be(24 to 31) & vpd44data_be(16 to 23) & vpd44data_be(8 to 15) & vpd44data_be(0 to 7);
+
+    -- use hardcoded data generated with this:
+    process (vpdadr) begin
+                       case vpdadr is
+                         when "000000" => vpd44data_be <= X"82200053";
+                         when "000001" => vpd44data_be <= X"656d7074";
+                         when "000010" => vpd44data_be <= X"69616e20";
+                         when "000011" => vpd44data_be <= X"53323431";
+                         when "000100" => vpd44data_be <= X"20504349";
+                         when "000101" => vpd44data_be <= X"65204341";
+                         when "000110" => vpd44data_be <= X"50493220";
+                         when "000111" => vpd44data_be <= X"41646170";
+                         when "001000" => vpd44data_be <= X"74657290";
+                         when "001001" => vpd44data_be <= X"5d00504e";
+                         when "001010" => vpd44data_be <= X"074e5341";
+                         when "001011" => vpd44data_be <= X"2e323431";
+                         when "001100" => vpd44data_be <= X"56311030";
+                         when "001101" => vpd44data_be <= X"30303030";
+                         when "001110" => vpd44data_be <= X"30303030";
+                         when "001111" => vpd44data_be <= X"30303030";
+                         when "010000" => vpd44data_be <= X"30303056";
+                         when "010001" => vpd44data_be <= X"32103030";
+                         when "010010" => vpd44data_be <= X"30303030";
+                         when "010011" => vpd44data_be <= X"30303030";
+                         when "010100" => vpd44data_be <= X"30303030";
+                         when "010101" => vpd44data_be <= X"30305633";
+                         when "010110" => vpd44data_be <= X"10303030";
+                         when "010111" => vpd44data_be <= X"30303030";
+                         when "011000" => vpd44data_be <= X"30303030";
+                         when "011001" => vpd44data_be <= X"30303030";
+                         when "011010" => vpd44data_be <= X"30563410";
+                         when "011011" => vpd44data_be <= X"30303030";
+                         when "011100" => vpd44data_be <= X"30303030";
+                         when "011101" => vpd44data_be <= X"30303030";
+                         when "011110" => vpd44data_be <= X"30303030";
+                         when "011111" => vpd44data_be <= X"5256041b";
+                         when "100000" => vpd44data_be <= X"00000078";
+                         when others => vpd44data_be <= X"00000000";
+                       end case;
+                     end process;
+
+ -- -- End Section -- --
+
+    i2c_byteop_d <= "000" when (vvpdadr_en = '1') else
+                    (std_logic_vector(unsigned(i2c_byteop_q) + 1)) when ((i2ch_ready_d = '1') and (i2ch_ready_q = '0') and (hi2c_rd_q = '1') and (i2c_monitor_ready_q = '1')) or
+                    ((hi2c_rd_q = '0') and (i2c_monitor_ready_q = '1') and (eeprom_wdelay_count_q = "100110001001011010000")) else
+                    i2c_byteop_q;
+    dff_i2c_byteop_q: capi_rise_vdff GENERIC MAP ( width => 3 ) PORT MAP (
+         dout => i2c_byteop_q,
+         din => i2c_byteop_d,
+         clk   => psl_clk
+    );
+    i2c_monitor_ready_d <= '0' when (hi2c_cmdval_d = '1') else
+                            '1' when (hi2c_cmdval_q5 = '1') else --wait a few cycles in between i2c command issues for ready to go low
+                            i2c_monitor_ready_q;
+    dff_i2c_monitor_ready_q: capi_rise_dff PORT MAP (
+         dout => i2c_monitor_ready_q,
+         din => i2c_monitor_ready_d,
+         clk   => psl_clk
+    );
+
+    eeprom_wdelay_count_d <= "000000000000000000000" when ((hi2c_rd_d = '0') and (i2ch_ready_q = '0')) else std_logic_vector(unsigned(eeprom_wdelay_count_q) + 1);
+    dff_eeprom_wdelay_count_q: capi_rise_vdff GENERIC MAP ( width => 21 ) PORT MAP (
+         dout => eeprom_wdelay_count_q,
+         din => eeprom_wdelay_count_d,
+         clk   => psl_clk
+    );
+
+
+    hi2c_cmdval_d <= '1' when ((vpd_usehardcoded = '0') and
+                     ((vvpdadr_en_q1 = '1' and i2ch_ready = '1' ) or
+                      (i2ch_ready = '1' and (i2c_byteop_d /= i2c_byteop_q) and ((i2c_byteop_d = "001") or (i2c_byteop_d = "010") or (i2c_byteop_d = "011"))))) else '0';
+    hi2c_rd_d <= '0' when ((vvpdadr_en_q1 = '1') and (vpd_rdy_flag = '1')) else--flag written to 1 by software indicates write of vpd storage
+                 '1' when ((vvpdadr_en_q1 = '1') and (vpd_rdy_flag = '0')) else--flag written to 0 by software indicates read of vpd storage
+                 hi2c_rd_q; --else hold on to prior value
+    hi2c_dataval_d <= '1' when ((hi2c_rd_d = '0') and (hi2c_cmdval_d = '1')) else
+                      '0'; --treat write data as valid any time a write is being performed
+    --hi2c_cmdin_d(0) <= '1';
+    hi2c_cmdin_d(0 to 5) <= vpdadr;
+    hi2c_cmdin_d(6 to 7) <= i2c_byteop_d(1 to 2); --byte address within dword
+    hi2c_datain_d <= vpdwrdat(24 to 31) when (i2c_byteop_d = "000") else
+                     vpdwrdat(16 to 23) when (i2c_byteop_d = "001") else
+                     vpdwrdat(8 to 15) when  (i2c_byteop_d = "010") else
+                     vpdwrdat(0 to 7);
+
+    dff_hi2c_cmdval_q: capi_rise_dff PORT MAP (
+         dout => hi2c_cmdval_q,
+         din => hi2c_cmdval_d,
+         clk   => psl_clk
+    );
+   hi2c_cmdval <= hi2c_cmdval_q;
+    dff_hi2c_cmdval_q1: capi_rise_dff PORT MAP (
+         dout => hi2c_cmdval_q1,
+         din => hi2c_cmdval_q,
+         clk   => psl_clk
+    );
+    dff_hi2c_cmdval_q2: capi_rise_dff PORT MAP (
+         dout => hi2c_cmdval_q2,
+         din => hi2c_cmdval_q1,
+         clk   => psl_clk
+    );
+    dff_hi2c_cmdval_q3: capi_rise_dff PORT MAP (
+         dout => hi2c_cmdval_q3,
+         din => hi2c_cmdval_q2,
+         clk   => psl_clk
+    );
+    dff_hi2c_cmdval_q4: capi_rise_dff PORT MAP (
+         dout => hi2c_cmdval_q4,
+         din => hi2c_cmdval_q3,
+         clk   => psl_clk
+    );
+    dff_hi2c_cmdval_q5: capi_rise_dff PORT MAP (
+         dout => hi2c_cmdval_q5,
+         din => hi2c_cmdval_q4,
+         clk   => psl_clk
+    );
+    dff_hi2c_rd_q: capi_rise_dff PORT MAP (
+         dout => hi2c_rd_q,
+         din => hi2c_rd_d,
+         clk   => psl_clk
+    );
+       dff_hi2c_dataval_q: capi_rise_dff PORT MAP (
+         dout => hi2c_dataval_q,
+         din => hi2c_dataval_d,
+         clk   => psl_clk
+    );
+    dff_hi2c_datain_q: capi_rise_vdff GENERIC MAP ( width => 8 ) PORT MAP (
+         dout => hi2c_datain_q,
+         din => hi2c_datain_d,
+         clk   => psl_clk
+    );
+       dff_hi2c_cmdin_q: capi_rise_vdff GENERIC MAP ( width => 8 ) PORT MAP (
+         dout => hi2c_cmdin_q,
+         din => hi2c_cmdin_d,
+         clk   => psl_clk
+    );
+
+   hi2c_rd <= hi2c_rd_q;
+   hi2c_dataval <= hi2c_dataval_q;
+   hi2c_datain <= hi2c_datain_q;
+   hi2c_cmdin <= hi2c_cmdin_q;
+
+    i2ch_ready_d <= i2ch_ready;
+    dff_i2ch_ready_q: capi_rise_dff PORT MAP (
+         dout => i2ch_ready_q,
+         din => i2ch_ready_d,
+         clk   => psl_clk
+    );
+
+
+  hi2c_addr <= "1010001"; --target the second lowest pages of the EEPROM. First 4 bits must be "1010"
+  hi2c_bytecnt <= "00000001"; --Will transfer 1 byte at a time. Must do 4 bytes total so four i2c operations for every vpd access.
+  hi2c_blk <= '0'; --not used
+  hi2c_cntlrsel <= "000"; --not used
+ -- ----------------------------------- --
+ -- Flash Address Register              --
+ -- ----------------------------------- --
+    vfadr_en <= vsec_0x50  and  cseb_be_l(3)  and  cseb_be_l(2)  and
+ -- AM Feb27, 2017                               cseb_be_l(1)  and  cseb_be_l(0)  and  wren_pulse ;
+                                cseb_be_l(1)  and  cseb_be_l(0)  and  wren_pulse_in ;
+
+    endff_vsec_fadr: capi_en_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => vsec_fadr,
+         en => vfadr_en,
+         din => vsec_wrdata,
+         clk   => psl_clk
+    );
+
+
+    vsec50data <= vsec_fadr;
+
+
+    f_start_blk <= vsec50data(6 to 15) ;
+    --v26bit f_read_start_addr = vsec_fadr;
+ -- -- End Section -- --
+
+ -- ----------------------------------- --
+ -- Flash Mux                           --
+ -- ----------------------------------- --
+    f_read_start_addr <= vsec_fadr ;
+    f_read_reqinternal <= flash_rd_req ;
+ -- -- End Section -- --
+
+ -- ----------------------------------- --
+ -- Flash Size Register                 --
+ -- ----------------------------------- --
+    vfsize_en <= vsec_0x54  and  cseb_be_l(2)  and
+ -- AM Feb27, 2017                                cseb_be_l(3)  and  wren_pulse ;
+                                 cseb_be_l(3)  and  wren_pulse_in ;
+
+
+    endff_vsec_fsize: capi_en_rise_vdff GENERIC MAP ( width => 16 ) PORT MAP (
+         dout => vsec_fsize,
+         en => vfsize_en,
+         din => vsec_wrdata(16 to 31),
+         clk   => psl_clk
+    );
+
+
+    vsec54data <= ( "0000000000000000" & vsec_fsize );
+
+
+    f_num_blocks <= std_logic_vector(unsigned(vsec_fsize) + 1) ;
+    f_num_words_m1 <= vsec_fsize;
+
+
+ -- -- End Section -- --
+
+ -- ----------------------------------- --
+ -- Flash Control / Status Register     --
+ -- ----------------------------------- --
+ -- AM Feb27, 2017   vfctl_en <= vsec_0x58  and  cseb_be_l(0)  and  wren_pulse ;
+    vfctl_en <= vsec_0x58  and  cseb_be_l(0)  and  wren_pulse_in ;
+
+
+    endff_f_program_req: capi_en_rise_dff PORT MAP (
+         dout => f_program_reqinternal,
+         en => vfctl_en,
+         din => vsec_wrdata(5),
+         clk   => psl_clk
+    );
+
+    endff_flash_rd_req: capi_en_rise_dff PORT MAP (
+         dout => flash_rd_req,
+         en => vfctl_en,
+         din => vsec_wrdata(4),
+         clk   => psl_clk
+    );
+
+
+    --concat(type=v32bit) (vsec58data, f_ready, f_done, 0b00, flash_rd_req, f_program_req, 0b0000000000,
+    --                                 f_stat_erase, f_stat_program, f_stat_read, 0b000, f_remainder);
+    vsec58data <= ( f_ready & f_done & "0" & f_states(31) & flash_rd_req & f_program_reqinternal & "0000000000" & f_stat_erase & f_stat_program & f_stat_read & f_program_data_valinternal & f_read_data_val & '0' & f_remainder );
+
+ -- -- End Section -- --
+
+ -- ------------------------------------------ --
+ -- Flash Read / Write Data Port Register      --
+ -- ------------------------------------------ --
+    -- READ --
+    vfrddp_read <= (vsec_0x5C)  and  cseb_be_l(3)  and  cseb_be_l(2)  and
+                                               cseb_be_l(1)  and  cseb_be_l(0)  and  rden_pulse_in ;
+
+    --vfrddp_en <= f_read_data_val  and   not vfrddp_val  and  f_read_reqinternal ;
+
+    --vfrddp_val_d <=  not (vfrddp_read  and  vfrddp_val)  and  (f_read_data_val  or  vfrddp_val) and f_read_reqinternal;
+    --dff_vfrddp_val: capi_rise_dff PORT MAP (
+    --     dout => vfrddp_val,
+    --     din => vfrddp_val_d,
+    --     clk   => psl_clk
+    --);
+
+
+    --f_read_data_ack <=  not vfrddp_val ;
+
+    vfrddp_en <= f_read_data_val  and  f_read_data_ack_int  and  f_read_reqinternal ;
+    vfrddp_val_d <= (f_read_data_val  and  not(fiveCfull_d)) ;
+    fiveCfull_d <= ((fiveCfull and not(vfrddp_read)) or vfrddp_en) and f_read_reqinternal;
+    dff_fiveCfull: capi_rise_dff PORT MAP (
+         dout => fiveCfull,
+         din => fiveCfull_d,
+         clk   => psl_clk
+    );
+
+    dff_f_read_data_ack: capi_rise_dff PORT MAP (
+         dout => f_read_data_ack_int,
+         din => vfrddp_val_d,
+         clk   => psl_clk
+    );
+
+
+    f_read_data_ack <=  f_read_data_ack_int ;
+
+    -- WRITE --
+    vfwrdp_en <= vsec_0x5C  and  cseb_be_l(3)  and  cseb_be_l(2)  and
+ -- AM Feb27, 2017                                cseb_be_l(1)  and  cseb_be_l(0)  and  wren_pulse  and  f_program_reqinternal ;
+                                 cseb_be_l(1)  and  cseb_be_l(0)  and  wren_pulse_in  and  f_program_reqinternal ;
+
+
+    f_program_data <= vsec5Cdata ;
+
+    f_program_data_val_d <=  not f_program_data_ack  and  (vfwrdp_en  or  f_program_data_valinternal) ;
+    dff_f_program_data_val: capi_rise_dff PORT MAP (
+         dout => f_program_data_valinternal,
+         din => f_program_data_val_d,
+         clk   => psl_clk
+    );
+
+
+    -- LATCH --
+    vsec5Cdata_d <= f_read_data when f_read_reqinternal='1' else vsec_wrdata;
+
+    vsec5C_reg_en <= vfrddp_en  or  (vfwrdp_en  and   not f_program_data_valinternal) ;
+
+    endff_vsec5Cdata: capi_en_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => vsec5Cdata,
+         en => vsec5C_reg_en,
+         din => vsec5Cdata_d,
+         clk   => psl_clk
+    );
+
+
+ -- -- End Section -- --
+--============================================================================================
+---- Address Decode
+--==============================================================================================--
+    vsec_addr <= cseb_addr_l ;
+
+    vsec_base <= '1' when (vsec_addr(21 to 24)  =  "0100") else '0';  -- 0x4xx Base for Xilinx --
+    vpd_base <= '1' when (vsec_addr(21 to 24)  =  "0000") else '0';
+
+    -- 5/1/2017 UltraScale+ - change from 0x40 to 0xB0
+    vpd_0x40 <= '1' when (vpd_base = '1'   and  (vsec_addr(25 to 32)  =  "10110000")) else '0';  -- 0x0B0 -- VPD Capability Structure--
+    vpd_0x44 <= '1' when (vpd_base = '1'   and  (vsec_addr(25 to 32)  =  "10110100")) else '0';  -- 0x0B4 -- VPD Data Port--
+
+    vsec_0x00 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00000000")) else '0' ; -- 0x00 -- Next Capability, Version, ID--
+    vsec_0x04 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00000100")) else '0' ; -- 0x04 -- VSEC Length, Rev, ID--
+    vsec_0x08 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00001000")) else '0' ; -- 0x08 -- Mode Control, Num AFUs--
+    vsec_0x0C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00001100")) else '0' ; -- 0x0C -- CAIA Version, PSL Version--
+
+    vsec_0x10 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00010000")) else '0' ; -- 0x10 -- Base Image Revision --
+  --bool vsec_0x14 = vsec_base & (vsec_addr.[25..32] == 0b00010100); /* 0x14 -- Reserved --
+  --bool vsec_0x18 = vsec_base & (vsec_addr.[25..32] == 0b00011000); /* 0x18 -- Reserved --
+  --bool vsec_0x1C = vsec_base & (vsec_addr.[25..32] == 0b00011100); /* 0x1C -- Reserved --
+
+    vsec_0x14 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32) = "00010100")) else '0'; -- /* 0x14 -- Reserved --
+    vsec_0x18 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00011000")) else '0'; -- /* 0x18 -- Reserved --
+    vsec_0x1C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00011100")) else '0'; -- /* 0x1C -- Reserved --
+
+    vsec_0x20 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00100000")) else '0' ; -- 0x20 -- AFU Descriptor Offset --
+    vsec_0x24 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00100100")) else '0' ; -- 0x24 -- AFU Descriptor Size --
+    vsec_0x28 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00101000")) else '0' ; -- 0x28 -- Problem State Offset --
+    vsec_0x2C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00101100")) else '0' ; -- 0x2C -- Problem State Size --
+
+    vsec_0x30 <= '1' when (vsec_base = '1'  and  (vsec_addr(25 to 32)  =  "00110000")) else '0'; -- /* 0x30 -- Reserved --
+    vsec_0x34 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00110100")) else '0'; -- /* 0x34 -- Reserved --
+    vsec_0x38 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00111000")) else '0'; -- /* 0x38 -- Reserved --
+    vsec_0x3C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00111100")) else '0'; -- /* 0x3C -- Reserved --
+
+    vsec_0x40 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01000000")) else '0' ; -- 0x40 -- PSL Programming Port--
+    vsec_0x44 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01000100")) else '0' ; -- 0x44 -- PSL Programming Control--
+    vsec_0x48 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01001000")) else '0'; -- /* 0x48 -- Reserved --
+    vsec_0x4C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01001100")) else '0'; -- /* 0x4C -- Reserved --
+
+    vsec_0x50 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01010000")) else '0' ; -- 0x50 -- Flash Address Register--
+    vsec_0x54 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01010100")) else '0' ; -- 0x54 -- Flash Size Register--
+    vsec_0x58 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01011000")) else '0' ; -- 0x58 -- Flash Status / Control --
+    vsec_0x5C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01011100")) else '0' ; -- 0x5C -- Flash Data Port --
+
+    vsec_0x60 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01100000")) else '0'; -- /* 0x60 -- Reserved --
+    vsec_0x64 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01100100")) else '0'; -- /* 0x64 -- Reserved --
+    vsec_0x68 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01101000")) else '0'; -- /* 0x68 -- Reserved --
+    vsec_0x6C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01101100")) else '0'; -- /* 0x6C -- Reserved --
+
+    vsec_0x70 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01110000")) else '0'; -- /* 0x70 -- Reserved --
+    vsec_0x74 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01110100")) else '0'; -- /* 0x74 -- Reserved --
+    vsec_0x78 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01111000")) else '0'; -- /* 0x78 -- Reserved --
+--     vsec_0x7C <= vsec_base and (vsec_addr(25 to 32)  =  "01111100"); -- /* 0x7C -- Reserved --
+
+  --bool vsec_0x70 = vsec_base & (vsec_addr.[25..32] == 0b01110000); /* 0x70 -- Reserved --
+  --bool vsec_0x74 = vsec_base & (vsec_addr.[25..32] == 0b01110100); /* 0x74 -- Reserved --
+  --bool vsec_0x78 = vsec_base & (vsec_addr.[25..32] == 0b01111000); /* 0x78 -- Reserved --
+  --bool vsec_0x7C = vsec_base & (vsec_addr.[25..32] == 0b01111100); /* 0x7C -- Reserved --
+--  cseb_waitrequest <= cseb_waitrequestinternal;
+  f_program_data_val <= f_program_data_valinternal;
+  f_program_req <= f_program_reqinternal;
+  f_read_req <= f_read_reqinternal;
+END capi_vsec;

--- a/U200/src/capi_vsec.vhdl
+++ b/U200/src/capi_vsec.vhdl
@@ -1326,49 +1326,50 @@ begin
     vpd_0x40 <= '1' when (vpd_base = '1'   and  (vsec_addr(25 to 32)  =  "10110000")) else '0';  -- 0x0B0 -- VPD Capability Structure--
     vpd_0x44 <= '1' when (vpd_base = '1'   and  (vsec_addr(25 to 32)  =  "10110100")) else '0';  -- 0x0B4 -- VPD Data Port--
 
-    vsec_0x00 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00000000")) else '0' ; -- 0x00 -- Next Capability, Version, ID--
-    vsec_0x04 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00000100")) else '0' ; -- 0x04 -- VSEC Length, Rev, ID--
-    vsec_0x08 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00001000")) else '0' ; -- 0x08 -- Mode Control, Num AFUs--
-    vsec_0x0C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00001100")) else '0' ; -- 0x0C -- CAIA Version, PSL Version--
+    -- change from 0x400 to 0x480 as the base.
+    vsec_0x00 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10000000")) else '0' ; -- 0x00 -- Next Capability, Version, ID--
+    vsec_0x04 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10000100")) else '0' ; -- 0x04 -- VSEC Length, Rev, ID--
+    vsec_0x08 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10001000")) else '0' ; -- 0x08 -- Mode Control, Num AFUs--
+    vsec_0x0C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10001100")) else '0' ; -- 0x0C -- CAIA Version, PSL Version--
 
-    vsec_0x10 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00010000")) else '0' ; -- 0x10 -- Base Image Revision --
+    vsec_0x10 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10010000")) else '0' ; -- 0x10 -- Base Image Revision --
   --bool vsec_0x14 = vsec_base & (vsec_addr.[25..32] == 0b00010100); /* 0x14 -- Reserved --
   --bool vsec_0x18 = vsec_base & (vsec_addr.[25..32] == 0b00011000); /* 0x18 -- Reserved --
   --bool vsec_0x1C = vsec_base & (vsec_addr.[25..32] == 0b00011100); /* 0x1C -- Reserved --
 
-    vsec_0x14 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32) = "00010100")) else '0'; -- /* 0x14 -- Reserved --
-    vsec_0x18 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00011000")) else '0'; -- /* 0x18 -- Reserved --
-    vsec_0x1C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00011100")) else '0'; -- /* 0x1C -- Reserved --
+    vsec_0x14 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32) = "10010100")) else '0'; -- /* 0x14 -- Reserved --
+    vsec_0x18 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "10011000")) else '0'; -- /* 0x18 -- Reserved --
+    vsec_0x1C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "10011100")) else '0'; -- /* 0x1C -- Reserved --
 
-    vsec_0x20 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00100000")) else '0' ; -- 0x20 -- AFU Descriptor Offset --
-    vsec_0x24 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00100100")) else '0' ; -- 0x24 -- AFU Descriptor Size --
-    vsec_0x28 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00101000")) else '0' ; -- 0x28 -- Problem State Offset --
-    vsec_0x2C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00101100")) else '0' ; -- 0x2C -- Problem State Size --
+    vsec_0x20 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10100000")) else '0' ; -- 0x20 -- AFU Descriptor Offset --
+    vsec_0x24 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10100100")) else '0' ; -- 0x24 -- AFU Descriptor Size --
+    vsec_0x28 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10101000")) else '0' ; -- 0x28 -- Problem State Offset --
+    vsec_0x2C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10101100")) else '0' ; -- 0x2C -- Problem State Size --
 
-    vsec_0x30 <= '1' when (vsec_base = '1'  and  (vsec_addr(25 to 32)  =  "00110000")) else '0'; -- /* 0x30 -- Reserved --
-    vsec_0x34 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00110100")) else '0'; -- /* 0x34 -- Reserved --
-    vsec_0x38 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00111000")) else '0'; -- /* 0x38 -- Reserved --
-    vsec_0x3C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00111100")) else '0'; -- /* 0x3C -- Reserved --
+    vsec_0x30 <= '1' when (vsec_base = '1'  and  (vsec_addr(25 to 32)  =  "10110000")) else '0'; -- /* 0x30 -- Reserved --
+    vsec_0x34 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "10110100")) else '0'; -- /* 0x34 -- Reserved --
+    vsec_0x38 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "10111000")) else '0'; -- /* 0x38 -- Reserved --
+    vsec_0x3C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "10111100")) else '0'; -- /* 0x3C -- Reserved --
 
-    vsec_0x40 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01000000")) else '0' ; -- 0x40 -- PSL Programming Port--
-    vsec_0x44 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01000100")) else '0' ; -- 0x44 -- PSL Programming Control--
-    vsec_0x48 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01001000")) else '0'; -- /* 0x48 -- Reserved --
-    vsec_0x4C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01001100")) else '0'; -- /* 0x4C -- Reserved --
+    vsec_0x40 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11000000")) else '0' ; -- 0x40 -- PSL Programming Port--
+    vsec_0x44 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11000100")) else '0' ; -- 0x44 -- PSL Programming Control--
+    vsec_0x48 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11001000")) else '0'; -- /* 0x48 -- Reserved --
+    vsec_0x4C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11001100")) else '0'; -- /* 0x4C -- Reserved --
 
-    vsec_0x50 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01010000")) else '0' ; -- 0x50 -- Flash Address Register--
-    vsec_0x54 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01010100")) else '0' ; -- 0x54 -- Flash Size Register--
-    vsec_0x58 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01011000")) else '0' ; -- 0x58 -- Flash Status / Control --
-    vsec_0x5C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01011100")) else '0' ; -- 0x5C -- Flash Data Port --
+    vsec_0x50 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11010000")) else '0' ; -- 0x50 -- Flash Address Register--
+    vsec_0x54 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11010100")) else '0' ; -- 0x54 -- Flash Size Register--
+    vsec_0x58 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11011000")) else '0' ; -- 0x58 -- Flash Status / Control --
+    vsec_0x5C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11011100")) else '0' ; -- 0x5C -- Flash Data Port --
 
-    vsec_0x60 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01100000")) else '0'; -- /* 0x60 -- Reserved --
-    vsec_0x64 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01100100")) else '0'; -- /* 0x64 -- Reserved --
-    vsec_0x68 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01101000")) else '0'; -- /* 0x68 -- Reserved --
-    vsec_0x6C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01101100")) else '0'; -- /* 0x6C -- Reserved --
+    vsec_0x60 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11100000")) else '0'; -- /* 0x60 -- Reserved --
+    vsec_0x64 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11100100")) else '0'; -- /* 0x64 -- Reserved --
+    vsec_0x68 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11101000")) else '0'; -- /* 0x68 -- Reserved --
+    vsec_0x6C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11101100")) else '0'; -- /* 0x6C -- Reserved --
 
-    vsec_0x70 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01110000")) else '0'; -- /* 0x70 -- Reserved --
-    vsec_0x74 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01110100")) else '0'; -- /* 0x74 -- Reserved --
-    vsec_0x78 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01111000")) else '0'; -- /* 0x78 -- Reserved --
---     vsec_0x7C <= vsec_base and (vsec_addr(25 to 32)  =  "01111100"); -- /* 0x7C -- Reserved --
+    vsec_0x70 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11110000")) else '0'; -- /* 0x70 -- Reserved --
+    vsec_0x74 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11110100")) else '0'; -- /* 0x74 -- Reserved --
+    vsec_0x78 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11111000")) else '0'; -- /* 0x78 -- Reserved --
+--     vsec_0x7C <= vsec_base and (vsec_addr(25 to 32)  =  "11111100"); -- /* 0x7C -- Reserved --
 
   --bool vsec_0x70 = vsec_base & (vsec_addr.[25..32] == 0b01110000); /* 0x70 -- Reserved --
   --bool vsec_0x74 = vsec_base & (vsec_addr.[25..32] == 0b01110100); /* 0x74 -- Reserved --

--- a/U200/src/capi_vsec.vhdl
+++ b/U200/src/capi_vsec.vhdl
@@ -1015,39 +1015,37 @@ begin
     -- use hardcoded data generated with this:
     process (vpdadr) begin
                        case vpdadr is
-                         when "000000" => vpd44data_be <= X"82200053";
-                         when "000001" => vpd44data_be <= X"656d7074";
-                         when "000010" => vpd44data_be <= X"69616e20";
-                         when "000011" => vpd44data_be <= X"53323431";
-                         when "000100" => vpd44data_be <= X"20504349";
-                         when "000101" => vpd44data_be <= X"65204341";
-                         when "000110" => vpd44data_be <= X"50493220";
-                         when "000111" => vpd44data_be <= X"41646170";
-                         when "001000" => vpd44data_be <= X"74657290";
-                         when "001001" => vpd44data_be <= X"5d00504e";
-                         when "001010" => vpd44data_be <= X"074e5341";
-                         when "001011" => vpd44data_be <= X"2e323431";
-                         when "001100" => vpd44data_be <= X"56311030";
+                         when "000000" => vpd44data_be <= X"82170055";
+                         when "000001" => vpd44data_be <= X"32303020";
+                         when "000010" => vpd44data_be <= X"50434965";
+                         when "000011" => vpd44data_be <= X"20434150";
+                         when "000100" => vpd44data_be <= X"49322041";
+                         when "000101" => vpd44data_be <= X"64617074";
+                         when "000110" => vpd44data_be <= X"6572905e";
+                         when "000111" => vpd44data_be <= X"00504e0b";
+                         when "001000" => vpd44data_be <= X"58696c69";
+                         when "001001" => vpd44data_be <= X"6e782e55";
+                         when "001010" => vpd44data_be <= X"32303056";
+                         when "001011" => vpd44data_be <= X"31103030";
+                         when "001100" => vpd44data_be <= X"30303030";
                          when "001101" => vpd44data_be <= X"30303030";
                          when "001110" => vpd44data_be <= X"30303030";
-                         when "001111" => vpd44data_be <= X"30303030";
-                         when "010000" => vpd44data_be <= X"30303056";
-                         when "010001" => vpd44data_be <= X"32103030";
+                         when "001111" => vpd44data_be <= X"30305631";
+                         when "010000" => vpd44data_be <= X"10303030";
+                         when "010001" => vpd44data_be <= X"30303030";
                          when "010010" => vpd44data_be <= X"30303030";
                          when "010011" => vpd44data_be <= X"30303030";
-                         when "010100" => vpd44data_be <= X"30303030";
-                         when "010101" => vpd44data_be <= X"30305633";
-                         when "010110" => vpd44data_be <= X"10303030";
+                         when "010100" => vpd44data_be <= X"30563110";
+                         when "010101" => vpd44data_be <= X"30303030";
+                         when "010110" => vpd44data_be <= X"30303030";
                          when "010111" => vpd44data_be <= X"30303030";
                          when "011000" => vpd44data_be <= X"30303030";
-                         when "011001" => vpd44data_be <= X"30303030";
-                         when "011010" => vpd44data_be <= X"30563410";
+                         when "011001" => vpd44data_be <= X"56311030";
+                         when "011010" => vpd44data_be <= X"30303030";
                          when "011011" => vpd44data_be <= X"30303030";
                          when "011100" => vpd44data_be <= X"30303030";
-                         when "011101" => vpd44data_be <= X"30303030";
-                         when "011110" => vpd44data_be <= X"30303030";
-                         when "011111" => vpd44data_be <= X"5256041b";
-                         when "100000" => vpd44data_be <= X"00000078";
+                         when "011101" => vpd44data_be <= X"30303052";
+                         when "011110" => vpd44data_be <= X"5601a278";
                          when others => vpd44data_be <= X"00000000";
                        end case;
                      end process;
@@ -1326,50 +1324,49 @@ begin
     vpd_0x40 <= '1' when (vpd_base = '1'   and  (vsec_addr(25 to 32)  =  "10110000")) else '0';  -- 0x0B0 -- VPD Capability Structure--
     vpd_0x44 <= '1' when (vpd_base = '1'   and  (vsec_addr(25 to 32)  =  "10110100")) else '0';  -- 0x0B4 -- VPD Data Port--
 
-    -- change from 0x400 to 0x480 as the base.
-    vsec_0x00 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10000000")) else '0' ; -- 0x00 -- Next Capability, Version, ID--
-    vsec_0x04 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10000100")) else '0' ; -- 0x04 -- VSEC Length, Rev, ID--
-    vsec_0x08 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10001000")) else '0' ; -- 0x08 -- Mode Control, Num AFUs--
-    vsec_0x0C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10001100")) else '0' ; -- 0x0C -- CAIA Version, PSL Version--
+    vsec_0x00 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00000000")) else '0' ; -- 0x00 -- Next Capability, Version, ID--
+    vsec_0x04 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00000100")) else '0' ; -- 0x04 -- VSEC Length, Rev, ID--
+    vsec_0x08 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00001000")) else '0' ; -- 0x08 -- Mode Control, Num AFUs--
+    vsec_0x0C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00001100")) else '0' ; -- 0x0C -- CAIA Version, PSL Version--
 
-    vsec_0x10 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10010000")) else '0' ; -- 0x10 -- Base Image Revision --
+    vsec_0x10 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00010000")) else '0' ; -- 0x10 -- Base Image Revision --
   --bool vsec_0x14 = vsec_base & (vsec_addr.[25..32] == 0b00010100); /* 0x14 -- Reserved --
   --bool vsec_0x18 = vsec_base & (vsec_addr.[25..32] == 0b00011000); /* 0x18 -- Reserved --
   --bool vsec_0x1C = vsec_base & (vsec_addr.[25..32] == 0b00011100); /* 0x1C -- Reserved --
 
-    vsec_0x14 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32) = "10010100")) else '0'; -- /* 0x14 -- Reserved --
-    vsec_0x18 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "10011000")) else '0'; -- /* 0x18 -- Reserved --
-    vsec_0x1C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "10011100")) else '0'; -- /* 0x1C -- Reserved --
+    vsec_0x14 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32) = "00010100")) else '0'; -- /* 0x14 -- Reserved --
+    vsec_0x18 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00011000")) else '0'; -- /* 0x18 -- Reserved --
+    vsec_0x1C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00011100")) else '0'; -- /* 0x1C -- Reserved --
 
-    vsec_0x20 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10100000")) else '0' ; -- 0x20 -- AFU Descriptor Offset --
-    vsec_0x24 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10100100")) else '0' ; -- 0x24 -- AFU Descriptor Size --
-    vsec_0x28 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10101000")) else '0' ; -- 0x28 -- Problem State Offset --
-    vsec_0x2C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "10101100")) else '0' ; -- 0x2C -- Problem State Size --
+    vsec_0x20 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00100000")) else '0' ; -- 0x20 -- AFU Descriptor Offset --
+    vsec_0x24 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00100100")) else '0' ; -- 0x24 -- AFU Descriptor Size --
+    vsec_0x28 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00101000")) else '0' ; -- 0x28 -- Problem State Offset --
+    vsec_0x2C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "00101100")) else '0' ; -- 0x2C -- Problem State Size --
 
-    vsec_0x30 <= '1' when (vsec_base = '1'  and  (vsec_addr(25 to 32)  =  "10110000")) else '0'; -- /* 0x30 -- Reserved --
-    vsec_0x34 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "10110100")) else '0'; -- /* 0x34 -- Reserved --
-    vsec_0x38 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "10111000")) else '0'; -- /* 0x38 -- Reserved --
-    vsec_0x3C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "10111100")) else '0'; -- /* 0x3C -- Reserved --
+    vsec_0x30 <= '1' when (vsec_base = '1'  and  (vsec_addr(25 to 32)  =  "00110000")) else '0'; -- /* 0x30 -- Reserved --
+    vsec_0x34 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00110100")) else '0'; -- /* 0x34 -- Reserved --
+    vsec_0x38 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00111000")) else '0'; -- /* 0x38 -- Reserved --
+    vsec_0x3C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "00111100")) else '0'; -- /* 0x3C -- Reserved --
 
-    vsec_0x40 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11000000")) else '0' ; -- 0x40 -- PSL Programming Port--
-    vsec_0x44 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11000100")) else '0' ; -- 0x44 -- PSL Programming Control--
-    vsec_0x48 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11001000")) else '0'; -- /* 0x48 -- Reserved --
-    vsec_0x4C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11001100")) else '0'; -- /* 0x4C -- Reserved --
+    vsec_0x40 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01000000")) else '0' ; -- 0x40 -- PSL Programming Port--
+    vsec_0x44 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01000100")) else '0' ; -- 0x44 -- PSL Programming Control--
+    vsec_0x48 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01001000")) else '0'; -- /* 0x48 -- Reserved --
+    vsec_0x4C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01001100")) else '0'; -- /* 0x4C -- Reserved --
 
-    vsec_0x50 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11010000")) else '0' ; -- 0x50 -- Flash Address Register--
-    vsec_0x54 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11010100")) else '0' ; -- 0x54 -- Flash Size Register--
-    vsec_0x58 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11011000")) else '0' ; -- 0x58 -- Flash Status / Control --
-    vsec_0x5C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "11011100")) else '0' ; -- 0x5C -- Flash Data Port --
+    vsec_0x50 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01010000")) else '0' ; -- 0x50 -- Flash Address Register--
+    vsec_0x54 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01010100")) else '0' ; -- 0x54 -- Flash Size Register--
+    vsec_0x58 <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01011000")) else '0' ; -- 0x58 -- Flash Status / Control --
+    vsec_0x5C <= '1' when (vsec_base = '1'   and  (vsec_addr(25 to 32)  =  "01011100")) else '0' ; -- 0x5C -- Flash Data Port --
 
-    vsec_0x60 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11100000")) else '0'; -- /* 0x60 -- Reserved --
-    vsec_0x64 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11100100")) else '0'; -- /* 0x64 -- Reserved --
-    vsec_0x68 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11101000")) else '0'; -- /* 0x68 -- Reserved --
-    vsec_0x6C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11101100")) else '0'; -- /* 0x6C -- Reserved --
+    vsec_0x60 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01100000")) else '0'; -- /* 0x60 -- Reserved --
+    vsec_0x64 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01100100")) else '0'; -- /* 0x64 -- Reserved --
+    vsec_0x68 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01101000")) else '0'; -- /* 0x68 -- Reserved --
+    vsec_0x6C <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01101100")) else '0'; -- /* 0x6C -- Reserved --
 
-    vsec_0x70 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11110000")) else '0'; -- /* 0x70 -- Reserved --
-    vsec_0x74 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11110100")) else '0'; -- /* 0x74 -- Reserved --
-    vsec_0x78 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "11111000")) else '0'; -- /* 0x78 -- Reserved --
---     vsec_0x7C <= vsec_base and (vsec_addr(25 to 32)  =  "11111100"); -- /* 0x7C -- Reserved --
+    vsec_0x70 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01110000")) else '0'; -- /* 0x70 -- Reserved --
+    vsec_0x74 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01110100")) else '0'; -- /* 0x74 -- Reserved --
+    vsec_0x78 <= '1' when (vsec_base = '1'  and (vsec_addr(25 to 32)  =  "01111000")) else '0'; -- /* 0x78 -- Reserved --
+--     vsec_0x7C <= vsec_base and (vsec_addr(25 to 32)  =  "01111100"); -- /* 0x7C -- Reserved --
 
   --bool vsec_0x70 = vsec_base & (vsec_addr.[25..32] == 0b01110000); /* 0x70 -- Reserved --
   --bool vsec_0x74 = vsec_base & (vsec_addr.[25..32] == 0b01110100); /* 0x74 -- Reserved --

--- a/U200/src/capi_xilmltbt.vhdl
+++ b/U200/src/capi_xilmltbt.vhdl
@@ -1,0 +1,249 @@
+-- *!***************************************************************************
+-- *! Copyright 2014-2018 International Business Machines
+-- *!
+-- *! Licensed under the Apache License, Version 2.0 (the "License");
+-- *! you may not use this file except in compliance with the License.
+-- *! You may obtain a copy of the License at
+-- *!
+-- *!     http://www.apache.org/licenses/LICENSE-2.0
+-- *!
+-- *! Unless required by applicable law or agreed to in writing, software
+-- *! distributed under the License is distributed on an "AS IS" BASIS,
+-- *! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- *! See the License for the specific language governing permissions and
+-- *! limitations under the License.
+-- *!
+-- *!***************************************************************************
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+ENTITY capi_xilmltbt IS
+  PORT(psl_clk: in std_logic;          -- 250Mhz PCIe clock
+       icap_clk: in std_logic;         -- 125Mhz clock
+
+       -- -------------- --
+       cpld_softreconfigreq: in std_logic;
+       cpld_user_bs_req: in std_logic;
+
+       --IP arbitration interface. This module is the master of the icap
+       icap_release: out std_logic;
+       icap_grant: out std_logic;
+       icap_request: in std_logic;
+
+
+       icap_mltbt_csib: out std_logic;
+       icap_mltbt_rdwrb: out std_logic;
+       icap_mltbt_writedata: out std_logic_vector(0 to 31);
+       icap_mltbt_takeover: out std_logic);
+
+END capi_xilmltbt;
+
+ARCHITECTURE capi_xilmltbt OF capi_xilmltbt IS
+
+Component capi_rise_dff
+  PORT (clk   : in std_logic;
+        dout  : out std_logic;
+        din   : in std_logic);
+End Component capi_rise_dff;
+
+Component capi_rise_dff_init1
+  PORT (clk   : in std_logic;
+        dout  : out std_logic;
+        din   : in std_logic);
+End Component capi_rise_dff_init1;
+
+Component capi_rise_vdff
+  GENERIC(width : positive );
+  PORT (clk   : in std_logic;
+        dout  : out std_logic_vector(0 to width-1);
+        din   : in std_logic_vector(0 to width-1));
+End Component capi_rise_vdff;
+
+Signal axi_icap_start_pre: std_logic;  -- bool
+
+Signal reset: std_logic;  -- bool
+Signal start: std_logic;  -- bool
+Signal start_l1: std_logic;  -- bool
+Signal start_l2: std_logic;  -- bool
+Signal start_l3: std_logic;  -- bool
+--Signal version: std_logic_vector(0 to 31);  -- int
+Signal wbstart_addr: std_logic_vector(31 downto 0);  -- v32bit
+Signal wbstart_addr_l1: std_logic_vector(31 downto 0);  -- v32bit
+Signal wbstart_addr_l2: std_logic_vector(31 downto 0);  -- v32bit
+Signal wbstart_addr_l3: std_logic_vector(31 downto 0);  -- v32bit
+Signal wbstart_addr_l3_swapendianness: std_logic_vector(31 downto 0);  -- v32bit
+signal count_valid: std_logic;
+signal count_valid_l: std_logic;
+signal count_nxt: std_logic_vector(3 downto 0);
+signal count_l: std_logic_vector(3 downto 0);
+Signal start_d: std_logic;  -- bool
+Signal start_q: std_logic;  -- bool
+signal start_pulse: std_logic;
+signal end_sequence: std_logic;
+signal end_sequence_l: std_logic;
+signal end_pulse: std_logic;
+signal instruction_address: std_logic_vector(3 downto 0);
+signal data: std_logic_vector(35 downto 0);
+signal icap_request_q: std_logic;
+signal icap_request_fall: std_logic;
+signal icap_mltbt_takeover_d: std_logic;
+signal icap_mltbt_takeover_q: std_logic;
+
+begin
+
+    dff_start: capi_rise_dff PORT MAP (
+         dout => start,
+         din => axi_icap_start_pre,
+         clk   => psl_clk
+    );
+
+    dff_startl1: capi_rise_dff PORT MAP (
+         dout => start_l1,
+         din => start,
+         clk   => icap_clk
+    );
+    dff_startl2: capi_rise_dff PORT MAP (
+         dout => start_l2,
+         din => start_l1,
+         clk   => icap_clk
+    );
+    dff_startl3: capi_rise_dff PORT MAP (
+         dout => start_l3,
+         din => start_l2,
+         clk   => icap_clk
+    );
+
+    axi_icap_start_pre <= cpld_softreconfigreq  or  start ;
+
+    -- This is for Semptian NSA241. 256MiB total. Split to 2 areas.
+    -- User image will be placed at 128MiB place 0x0800_0000 
+    -- RS pins not used in SPI mode
+
+    -- wbstart_addr: [31,30]: RS | [29]: RS_TS_B | [28:0]: START_ADDR
+    -- Wait address expansion
+    wbstart_addr <= ( "000" & "0" & cpld_user_bs_req & "000" & "000000000000000000000000" );
+
+    dff_wbstart_addrl1: capi_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => wbstart_addr_l1,
+         din => wbstart_addr,
+         clk   => icap_clk
+    );
+    dff_wbstart_addrl2: capi_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => wbstart_addr_l2,
+         din => wbstart_addr_l1,
+         clk   => icap_clk
+    );
+    dff_wbstart_addrl3: capi_rise_vdff GENERIC MAP ( width => 32 ) PORT MAP (
+         dout => wbstart_addr_l3,
+         din => wbstart_addr_l2,
+         clk   => icap_clk
+    );
+    wbstart_addr_l3_swapendianness <= wbstart_addr_l3(24) & wbstart_addr_l3(25) & wbstart_addr_l3(26) & wbstart_addr_l3(27) & wbstart_addr_l3(28)
+     & wbstart_addr_l3(29) & wbstart_addr_l3(30) & wbstart_addr_l3(31) & wbstart_addr_l3(16) & wbstart_addr_l3(17) & wbstart_addr_l3(18)
+     & wbstart_addr_l3(19) & wbstart_addr_l3(20) & wbstart_addr_l3(21) & wbstart_addr_l3(22) & wbstart_addr_l3(23) & wbstart_addr_l3(8)
+     & wbstart_addr_l3(9) & wbstart_addr_l3(10) & wbstart_addr_l3(11) & wbstart_addr_l3(12) & wbstart_addr_l3(13) & wbstart_addr_l3(14)
+     & wbstart_addr_l3(15) & wbstart_addr_l3(0) & wbstart_addr_l3(1) & wbstart_addr_l3(2) & wbstart_addr_l3(3) & wbstart_addr_l3(4)
+     & wbstart_addr_l3(5) & wbstart_addr_l3(6) & wbstart_addr_l3(7);--ICAP takes swapped endianness on each byte
+
+    start_pulse <= start_d and not(start_q);
+    end_sequence <= '1' when ((count_l(3) = '1') and (count_l(2) = '0') and (count_l(1) = '0') and (count_l(0) = '1')) else '0';
+    end_pulse <= end_sequence and not(end_sequence_l);
+    count_valid <= '1' when (start_pulse = '1') else
+                   '0' when (end_pulse = '1') else
+                   count_valid_l;
+    count_nxt <= (std_logic_vector(unsigned(count_l) + 1)) when (count_valid = '1') else
+                   "0000";
+
+    start_d <= start_l3 and icap_request_fall;
+    dff_start_q: capi_rise_dff PORT MAP (
+         dout => start_q,
+         din => start_d,
+         clk   => icap_clk
+    );
+
+    dff_end_sequence_l: capi_rise_dff PORT MAP (
+         dout => end_sequence_l,
+         din => end_sequence,
+         clk   => icap_clk
+    );
+
+    dff_count_valid_l: capi_rise_dff PORT MAP (
+         dout => count_valid_l,
+         din => count_valid,
+         clk   => icap_clk
+    );
+
+    dff_count_l: capi_rise_vdff GENERIC MAP ( width => 4) PORT MAP (
+         dout => count_l,
+         din => count_nxt,
+         clk   => icap_clk
+    );
+
+instruction_address <= count_l;
+
+process (instruction_address, wbstart_addr_l3_swapendianness)
+begin
+  case instruction_address is
+    when "0000" => data <= X"3FFFFFFFF";
+    when "0001" => data <= X"0FFFFFFFF";
+    when "0010" => data <= X"05599AA66";
+    when "0011" => data <= X"004000000";
+    when "0100" => data <= X"00C400080";
+    when "0101" => data <= X"0" & wbstart_addr_l3_swapendianness;
+    when "0110" => data <= X"00C000180";
+    when "0111" => data <= X"0000000F0";
+    when "1000" => data <= X"004000000";
+    when "1001" => data <= X"3FFFFFFFF";
+    when "1010" => data <= X"3FFFFFFFF";
+    when "1011" => data <= X"3FFFFFFFF";
+    when "1100" => data <= X"3FFFFFFFF";
+    when "1101" => data <= X"3FFFFFFFF";
+    when "1110" => data <= X"3FFFFFFFF";
+    when "1111" => data <= X"3FFFFFFFF";
+    when others => data <= X"3FFFFFFFF";
+  end case ;
+end process;
+
+    dff_icap_mltbt_csib: capi_rise_dff PORT MAP (
+         dout => icap_mltbt_csib,
+         din => data(33),
+         clk   => icap_clk
+    );
+    dff_icap_mltbt_rdwrb: capi_rise_dff PORT MAP (
+         dout => icap_mltbt_rdwrb,
+         din => data(32),
+         clk   => icap_clk
+    );
+    dff_icap_mltbt_writedata: capi_rise_vdff GENERIC MAP ( width => 32) PORT MAP (
+         dout => icap_mltbt_writedata,
+         din => data(31 downto 0),
+         clk   => icap_clk
+    );
+
+    --Arbitration Logic. Multiboot permanently takes over until image is blown away.
+    --Temporarily disabling sem core until more robust arbiter can be implemented
+    --icap_release <= start_l3;
+    --icap_grant <= not(start_l3);
+    icap_release <= '1';
+    icap_grant <= '0';
+
+    dff_icap_request_q: capi_rise_dff PORT MAP (
+         dout => icap_request_q,
+         din => icap_request,
+         clk   => icap_clk
+    );
+    --icap_request_fall <= icap_request_q and not(icap_request);
+    --icap_mltbt_takeover_d <= icap_mltbt_takeover_q or icap_request_fall;
+    icap_request_fall <= '1';
+    icap_mltbt_takeover_d <= '1';
+    --dff_icap_mktbt_takeover_q: capi_rise_dff PORT MAP (
+    dff_icap_mktbt_takeover_q: capi_rise_dff_init1 PORT MAP (
+         dout => icap_mltbt_takeover_q,
+         din => icap_mltbt_takeover_d,
+         clk   => icap_clk
+    );
+    icap_mltbt_takeover <= icap_mltbt_takeover_q;
+
+END capi_xilmltbt;

--- a/U200/tcl/add_ip.tcl
+++ b/U200/tcl/add_ip.tcl
@@ -1,0 +1,32 @@
+############################################################################
+############################################################################
+##
+## Copyright 2018 International Business Machines
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+############################################################################
+############################################################################
+
+# add pcie4_uscale_plus
+add_files -norecurse                             $ip_dir/pcie4_uscale_plus_0/pcie4_uscale_plus_0.xci  -force >> $log_file
+# export_ip_user_files -of_objects      [get_files $ip_dir/pcie4_uscale_plus_0/pcie4_uscale_plus_0.xci] -no_script -sync -force >> $log_file
+# set_property used_in_simulation false [get_files $ip_dir/pcie4_uscale_plus_0/pcie4_uscale_plus_0.xci] >> $log_file
+# add sem_ultra
+add_files -norecurse                             $ip_dir/sem_ultra_0/sem_ultra_0.xci  -force >> $log_file
+export_ip_user_files -of_objects      [get_files $ip_dir/sem_ultra_0/sem_ultra_0.xci] -no_script -sync -force >> $log_file
+set_property used_in_simulation false [get_files $ip_dir/sem_ultra_0/sem_ultra_0.xci]  >> $log_file
+# add uscale_plus_clk_wiz
+add_files -norecurse                             $ip_dir/uscale_plus_clk_wiz/uscale_plus_clk_wiz.xci  -force >> $log_file
+export_ip_user_files -of_objects      [get_files $ip_dir/uscale_plus_clk_wiz/uscale_plus_clk_wiz.xci] -no_script -sync -force >> $log_file
+set_property used_in_simulation false [get_files $ip_dir/uscale_plus_clk_wiz/uscale_plus_clk_wiz.xci] >> $log_file

--- a/U200/tcl/add_src.tcl
+++ b/U200/tcl/add_src.tcl
@@ -1,0 +1,34 @@
+############################################################################
+############################################################################
+##
+## Copyright 2018 International Business Machines
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+############################################################################
+############################################################################
+
+#Adding source files
+add_files -norecurse $common_src/capi_en_rise_dff.vhdl >> $log_file
+add_files -norecurse $common_src/capi_en_rise_vdff.vhdl >> $log_file
+add_files -norecurse $common_src/CAPI_FPGA_RESET_GEN.v >> $log_file
+add_files -norecurse $common_src/capi_rise_dff_init1.vhdl >> $log_file
+add_files -norecurse $common_src/capi_rise_dff.vhdl >> $log_file
+add_files -norecurse $common_src/capi_rise_vdff.vhdl >> $log_file
+add_files -norecurse $common_src/capi_sreconfig.vhdl >> $log_file
+add_files -norecurse $common_src/CAPI_STP_COUNTER.v >> $log_file
+add_files -norecurse $common_src/capi_fifo.vhdl >> $log_file
+add_files -norecurse $common_src/capi_ram.vhdl >> $log_file
+add_files -norecurse $common_src/capi_rise_dff.vhdl >> $log_file
+
+add_files -norecurse $fpga_src/capi_svcrc3srl.vhdl >> $log_file

--- a/U200/tcl/create_ip.tcl
+++ b/U200/tcl/create_ip.tcl
@@ -18,10 +18,10 @@
 ############################################################################
 ############################################################################
 
-# Flyslice FX609 has changed following:
+# Xilinx U200 has changed following:
 # Max LINK SPEED: 8GT/s
 # Max LINK WIDTH: X16
-# SUBSYSTEM_ID: 0x0661
+# SUBSYSTEM_ID: 0x0665
 # PCIE_ID_IF = flase
 # PCIE BANK 227/226/225/224 (SLR1 X1Y2)
 

--- a/U200/tcl/create_ip.tcl
+++ b/U200/tcl/create_ip.tcl
@@ -44,7 +44,7 @@ set_property -dict [list                                               \
                     CONFIG.PF0_CLASS_CODE {1200ff}                     \
                     CONFIG.PF0_DEVICE_ID {0477}                        \
                     CONFIG.PF0_REVISION_ID {02}                        \
-                    CONFIG.PF0_SUBSYSTEM_ID {0660}                     \
+                    CONFIG.PF0_SUBSYSTEM_ID {0665}                     \
                     CONFIG.PF0_SUBSYSTEM_VENDOR_ID {1014}              \
                     CONFIG.PCIE_ID_IF {false}                          \
                     CONFIG.ins_loss_profile {Add-in_card}              \

--- a/U200/tcl/create_ip.tcl
+++ b/U200/tcl/create_ip.tcl
@@ -1,0 +1,218 @@
+############################################################################
+############################################################################
+##
+## Copyright 2018 International Business Machines
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+############################################################################
+############################################################################
+
+# Flyslice FX609 has changed following:
+# Max LINK SPEED: 8GT/s
+# Max LINK WIDTH: X16
+# SUBSYSTEM_ID: 0x0661
+# PCIE_ID_IF = flase
+# PCIE BANK 227/226/225/224 (SLR1 X1Y2)
+
+# user can set a specific value for the Action clock lower than the 250MHz nominal clock
+set action_clock_freq "250MHz"
+#overide default value if variable exist
+set action_clock_freq $::env(FPGA_ACTION_CLK)
+
+
+# Create PCIe4 IP
+create_ip -name pcie4_uscale_plus -vendor xilinx.com -library ip -module_name pcie4_uscale_plus_0 -dir $ip_dir >> $log_file
+set_property -dict [list                                               \
+                    CONFIG.enable_gen4 {false}                         \
+                    CONFIG.gen4_eieos_0s7 {true}                       \
+                    CONFIG.PL_LINK_CAP_MAX_LINK_SPEED {8.0_GT/s}       \
+                    CONFIG.PL_LINK_CAP_MAX_LINK_WIDTH {X16}            \
+                    CONFIG.AXISTEN_IF_EXT_512_CQ_STRADDLE {true}       \
+                    CONFIG.AXISTEN_IF_EXT_512_RC_4TLP_STRADDLE {false} \
+                    CONFIG.axisten_if_enable_client_tag {true}         \
+                    CONFIG.PF0_CLASS_CODE {1200ff}                     \
+                    CONFIG.PF0_DEVICE_ID {0477}                        \
+                    CONFIG.PF0_REVISION_ID {02}                        \
+                    CONFIG.PF0_SUBSYSTEM_ID {0660}                     \
+                    CONFIG.PF0_SUBSYSTEM_VENDOR_ID {1014}              \
+                    CONFIG.PCIE_ID_IF {false}                          \
+                    CONFIG.ins_loss_profile {Add-in_card}              \
+                    CONFIG.PHY_LP_TXPRESET {4}                         \
+                    CONFIG.pf0_bar0_64bit {true}                       \
+                    CONFIG.pf0_bar0_prefetchable {true}                \
+                    CONFIG.pf0_bar0_scale {Megabytes}                  \
+                    CONFIG.pf0_bar0_size {256}                         \
+                    CONFIG.pf0_bar2_enabled {true}                     \
+                    CONFIG.pf0_bar2_64bit {true}                       \
+                    CONFIG.pf0_bar2_prefetchable {true}                \
+                    CONFIG.pf0_bar4_enabled {true}                     \
+                    CONFIG.pf0_bar4_64bit {true}                       \
+                    CONFIG.pf0_bar4_prefetchable {true}                \
+                    CONFIG.pf0_bar4_scale {Gigabytes}                  \
+                    CONFIG.pf0_bar4_size {256}                         \
+                    CONFIG.pf0_dev_cap_max_payload {512_bytes}         \
+                    CONFIG.vendor_id {1014}                            \
+                    CONFIG.ext_pcie_cfg_space_enabled {true}           \
+                    CONFIG.legacy_ext_pcie_cfg_space_enabled {true}    \
+                    CONFIG.mode_selection {Advanced}                   \
+                    CONFIG.en_gt_selection {true}                      \
+                    CONFIG.pcie_blk_locn {X1Y2}                        \
+                    CONFIG.gen_x0y1 {false}                            \
+                    CONFIG.gen_x1y2 {true}                             \
+                    CONFIG.select_quad {GTY_Quad_227}                  \
+                    CONFIG.AXISTEN_IF_EXT_512_RQ_STRADDLE {true}       \
+                    CONFIG.PF0_MSIX_CAP_PBA_BIR {BAR_1:0}              \
+                    CONFIG.PF0_MSIX_CAP_TABLE_BIR {BAR_1:0}            \
+                    CONFIG.PF2_DEVICE_ID {9048}                        \
+                    CONFIG.PF3_DEVICE_ID {9048}                        \
+                    CONFIG.pf2_bar2_enabled {true}                     \
+                    CONFIG.pf3_bar2_enabled {true}                     \
+                    CONFIG.pf1_bar2_enabled {true}                     \
+                    CONFIG.pf1_bar2_type {Memory}                      \
+                    CONFIG.pf1_bar4_type {Memory}                      \
+                    CONFIG.pf2_bar2_type {Memory}                      \
+                    CONFIG.pf2_bar4_type {Memory}                      \
+                    CONFIG.pf3_bar2_type {Memory}                      \
+                    CONFIG.pf3_bar4_type {Memory}                      \
+                    CONFIG.pf0_bar2_type {Memory}                      \
+                    CONFIG.pf0_bar4_type {Memory}                      \
+                    CONFIG.pf1_bar4_enabled {true}                     \
+                    CONFIG.pf1_bar4_scale {Gigabytes}                  \
+                    CONFIG.pf1_vendor_id {1014}                        \
+                    CONFIG.pf2_vendor_id {1014}                        \
+                    CONFIG.pf3_vendor_id {1014}                        \
+                    CONFIG.pf1_bar0_scale {Megabytes}                  \
+                    CONFIG.pf1_bar0_size {256}                         \
+                    CONFIG.axisten_if_width {512_bit}                  \
+                    CONFIG.pf1_bar4_size {256}                         \
+                    CONFIG.pf2_bar4_enabled {true}                     \
+                    CONFIG.pf2_bar4_scale {Gigabytes}                  \
+                    CONFIG.pf2_bar0_scale {Megabytes}                  \
+                    CONFIG.pf2_bar0_size {256}                         \
+                    CONFIG.pf2_bar4_size {256}                         \
+                    CONFIG.pf3_bar4_enabled {true}                     \
+                    CONFIG.pf3_bar4_scale {Gigabytes}                  \
+                    CONFIG.pf3_bar0_scale {Megabytes}                  \
+                    CONFIG.pf3_bar0_size {256}                         \
+                    CONFIG.pf3_bar4_size {256}                         \
+                    CONFIG.coreclk_freq {500}                          \
+                    CONFIG.plltype {QPLL0}                             \
+                    CONFIG.axisten_freq {250}                          \
+                   ] [get_ips pcie4_uscale_plus_0] >> $log_file
+
+
+#Create 250MHz Clock IP
+#set_property -dict [list CONFIG.CLKIN1_JITTER_PS {40.0} \
+#CONFIG.CLKOUT1_DRIVES {BUFG} \
+#CONFIG.CLKOUT1_JITTER {85.736} \
+#CONFIG.CLKOUT1_PHASE_ERROR {79.008} \
+#CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {250} \
+#CONFIG.CLKOUT2_DRIVES {BUFG} \
+#CONFIG.CLKOUT2_JITTER {98.122} \
+#CONFIG.CLKOUT2_PHASE_ERROR {79.008} \
+#CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {125} \
+#CONFIG.CLKOUT2_USED {true} \
+#CONFIG.CLKOUT3_DRIVES {BUFGCE} \
+#CONFIG.CLKOUT3_JITTER {98.122} \
+#CONFIG.CLKOUT3_PHASE_ERROR {79.008} \
+#CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {125} \
+#CONFIG.CLKOUT3_USED {true} \
+#CONFIG.FEEDBACK_SOURCE {FDBK_AUTO} \
+#CONFIG.MMCM_CLKFBOUT_MULT_F {5.000} \
+#CONFIG.MMCM_CLKIN1_PERIOD {4.000} \
+#CONFIG.MMCM_CLKIN2_PERIOD {10.0} \
+#CONFIG.MMCM_CLKOUT0_DIVIDE_F {5.000} \
+#CONFIG.MMCM_CLKOUT1_DIVIDE {10} \
+#CONFIG.MMCM_CLKOUT2_DIVIDE {10} \
+#CONFIG.MMCM_DIVCLK_DIVIDE {1} \
+#CONFIG.NUM_OUT_CLKS {3} \
+#CONFIG.PRIM_IN_FREQ {250}] [get_ips uscale_plus_clk_wiz]
+
+if { $action_clock_freq == "225MHZ" } {
+  #Create 225MHz specific Clock IP
+  puts " CAUTION: Action clock has been set to 225MHZ (default is 250MHZ)"
+
+  create_ip -name clk_wiz -vendor xilinx.com -library ip -module_name uscale_plus_clk_wiz -dir  $ip_dir >> $log_file
+  #Increase psl clock period by 10% to ease timing
+  set_property -dict [list                                        \
+                    CONFIG.CLKIN1_JITTER_PS {40.0}              \
+                    CONFIG.CLKOUT1_DRIVES {BUFG}                \
+                    CONFIG.CLKOUT1_JITTER {88.305}              \
+                    CONFIG.CLKOUT1_PHASE_ERROR {80.553}         \
+                    CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {225.000} \
+                    CONFIG.CLKOUT2_DRIVES {BUFG}                \
+                    CONFIG.CLKOUT2_JITTER {99.067}              \
+                    CONFIG.CLKOUT2_PHASE_ERROR {80.553}         \
+                    CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {125.000} \
+                    CONFIG.CLKOUT2_USED {true}                  \
+                    CONFIG.CLKOUT3_DRIVES {BUFGCE}              \
+                    CONFIG.CLKOUT3_JITTER {99.067}              \
+                    CONFIG.CLKOUT3_PHASE_ERROR {80.553}         \
+                    CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {125.000} \
+                    CONFIG.CLKOUT3_USED {true}                  \
+                    CONFIG.FEEDBACK_SOURCE {FDBK_AUTO}          \
+                    CONFIG.MMCM_CLKFBOUT_MULT_F {4.500}         \
+                    CONFIG.MMCM_CLKIN1_PERIOD {4.000}           \
+                    CONFIG.MMCM_CLKIN2_PERIOD {14.999}          \
+                    CONFIG.MMCM_CLKOUT0_DIVIDE_F {5.000}        \
+                    CONFIG.MMCM_CLKOUT1_DIVIDE {9}              \
+                    CONFIG.MMCM_CLKOUT2_DIVIDE {9}              \
+                    CONFIG.MMCM_DIVCLK_DIVIDE {1}               \
+                    CONFIG.NUM_OUT_CLKS {3}                     \
+                    CONFIG.PRIM_IN_FREQ {250.000}               \
+                    CONFIG.USE_INCLK_SWITCHOVER {false}         \
+                   ] [get_ips uscale_plus_clk_wiz] >> $log_file
+} else {
+# create a 250MHz Clock IP
+  puts " Action clock is set to 250MHZ (default)"
+  create_ip -name clk_wiz -vendor xilinx.com -library ip -module_name uscale_plus_clk_wiz -dir $ip_dir >> $log_file
+  set_property -dict [list                                    \
+                    CONFIG.CLKIN1_JITTER_PS {40.0}          \
+                    CONFIG.CLKOUT1_DRIVES {BUFG}            \
+                    CONFIG.CLKOUT1_JITTER {85.736}          \
+                    CONFIG.CLKOUT1_PHASE_ERROR {79.008}     \
+                    CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {250.000} \
+                    CONFIG.CLKOUT2_DRIVES {BUFG}            \
+                    CONFIG.CLKOUT2_JITTER {98.122}          \
+                    CONFIG.CLKOUT2_PHASE_ERROR {79.008}     \
+                    CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {125} \
+                    CONFIG.CLKOUT2_USED {true}              \
+                    CONFIG.CLKOUT3_DRIVES {BUFGCE}          \
+                    CONFIG.CLKOUT3_JITTER {98.122}          \
+                    CONFIG.CLKOUT3_PHASE_ERROR {79.008}     \
+                    CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {125} \
+                    CONFIG.CLKOUT3_USED {true}              \
+                    CONFIG.FEEDBACK_SOURCE {FDBK_AUTO}      \
+                    CONFIG.MMCM_CLKFBOUT_MULT_F {5.000}     \
+                    CONFIG.MMCM_CLKIN1_PERIOD {4.000}       \
+                    CONFIG.MMCM_CLKIN2_PERIOD {10.000}      \
+                    CONFIG.MMCM_CLKOUT0_DIVIDE_F {5.000}    \
+                    CONFIG.MMCM_CLKOUT1_DIVIDE {10}         \
+                    CONFIG.MMCM_CLKOUT2_DIVIDE {10}         \
+                    CONFIG.MMCM_DIVCLK_DIVIDE {1}           \
+                    CONFIG.NUM_OUT_CLKS {3}                 \
+                    CONFIG.PRIM_IN_FREQ {250}               \
+                   ] [get_ips uscale_plus_clk_wiz] >> $log_file
+}
+
+# Create UltraScale Soft Error Mitigation IP
+create_ip -name sem_ultra -vendor xilinx.com -library ip -module_name sem_ultra_0 -dir $ip_dir >> $log_file
+set_property -dict [list                       \
+                    CONFIG.MODE {detect_only}  \
+                    CONFIG.CLOCK_PERIOD {8000} \
+                   ] [get_ips sem_ultra_0] >> $log_file
+
+set_property generate_synth_checkpoint false [get_files pcie4_uscale_plus_0.xci] >> $log_file
+set_property generate_synth_checkpoint false [get_files uscale_plus_clk_wiz.xci] >> $log_file
+set_property generate_synth_checkpoint false [get_files sem_ultra_0.xci] >> $log_file

--- a/U200/tcl/patch_ip.tcl
+++ b/U200/tcl/patch_ip.tcl
@@ -1,0 +1,28 @@
+#!/bin/sh
+############################################################################
+############################################################################
+##
+## Copyright 2018 International Business Machines
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+############################################################################
+############################################################################
+
+set pcie_source $capi_bsp_ip_dir/src/pcie4_uscale_plus_0/synth/pcie4_uscale_plus_0.v
+
+# Adding PF0_PCIE_CAP_NEXTPTR and setting PF0_SECONDARY_PCIE_CAP_NEXTPTR to 0x400
+exec /bin/bash -c "sed -i \"s/PF0_DEVICE_ID=0x0477/PF0_DEVICE_ID=0x0477,PF0_PCIE_CAP_NEXTPTR=0xb0/\" $pcie_source"
+exec /bin/bash -c "sed -i \"s/PF0_SECONDARY_PCIE_CAP_NEXTPTR=0x480/PF0_SECONDARY_PCIE_CAP_NEXTPTR=0x400/\" $pcie_source"
+exec /bin/bash -c "sed -i \"s/PF0_SECONDARY_PCIE_CAP_NEXTPTR('H480)/PF0_SECONDARY_PCIE_CAP_NEXTPTR('H400)/\" $pcie_source"
+exec /bin/bash -c "sed -i \"/PF0_DEVICE_ID(/ a\\\n\\    .PF0_PCIE_CAP_NEXTPTR('HB0),\" $pcie_source"

--- a/U200/tcl/patch_ip.tcl
+++ b/U200/tcl/patch_ip.tcl
@@ -19,10 +19,10 @@
 ############################################################################
 ############################################################################
 
-set pcie_source $capi_bsp_ip_dir/src/pcie4_uscale_plus_0/synth/pcie4_uscale_plus_0.v
-
-# Adding PF0_PCIE_CAP_NEXTPTR and setting PF0_SECONDARY_PCIE_CAP_NEXTPTR to 0x400
-exec /bin/bash -c "sed -i \"s/PF0_DEVICE_ID=0x0477/PF0_DEVICE_ID=0x0477,PF0_PCIE_CAP_NEXTPTR=0xb0/\" $pcie_source"
-exec /bin/bash -c "sed -i \"s/PF0_SECONDARY_PCIE_CAP_NEXTPTR=0x480/PF0_SECONDARY_PCIE_CAP_NEXTPTR=0x400/\" $pcie_source"
-exec /bin/bash -c "sed -i \"s/PF0_SECONDARY_PCIE_CAP_NEXTPTR('H480)/PF0_SECONDARY_PCIE_CAP_NEXTPTR('H400)/\" $pcie_source"
-exec /bin/bash -c "sed -i \"/PF0_DEVICE_ID(/ a\\\n\\    .PF0_PCIE_CAP_NEXTPTR('HB0),\" $pcie_source"
+#set pcie_source $capi_bsp_ip_dir/src/pcie4_uscale_plus_0/synth/pcie4_uscale_plus_0.v
+#
+## Adding PF0_PCIE_CAP_NEXTPTR and setting PF0_SECONDARY_PCIE_CAP_NEXTPTR to 0x400
+#exec /bin/bash -c "sed -i \"s/PF0_DEVICE_ID=0x0477/PF0_DEVICE_ID=0x0477,PF0_PCIE_CAP_NEXTPTR=0xb0/\" $pcie_source"
+#exec /bin/bash -c "sed -i \"s/PF0_SECONDARY_PCIE_CAP_NEXTPTR=0x480/PF0_SECONDARY_PCIE_CAP_NEXTPTR=0x400/\" $pcie_source"
+#exec /bin/bash -c "sed -i \"s/PF0_SECONDARY_PCIE_CAP_NEXTPTR('H480)/PF0_SECONDARY_PCIE_CAP_NEXTPTR('H400)/\" $pcie_source"
+#exec /bin/bash -c "sed -i \"/PF0_DEVICE_ID(/ a\\\n\\    .PF0_PCIE_CAP_NEXTPTR('HB0),\" $pcie_source"

--- a/U200/tcl/patch_ip.tcl
+++ b/U200/tcl/patch_ip.tcl
@@ -19,10 +19,10 @@
 ############################################################################
 ############################################################################
 
-#set pcie_source $capi_bsp_ip_dir/src/pcie4_uscale_plus_0/synth/pcie4_uscale_plus_0.v
-#
-## Adding PF0_PCIE_CAP_NEXTPTR and setting PF0_SECONDARY_PCIE_CAP_NEXTPTR to 0x400
-#exec /bin/bash -c "sed -i \"s/PF0_DEVICE_ID=0x0477/PF0_DEVICE_ID=0x0477,PF0_PCIE_CAP_NEXTPTR=0xb0/\" $pcie_source"
-#exec /bin/bash -c "sed -i \"s/PF0_SECONDARY_PCIE_CAP_NEXTPTR=0x480/PF0_SECONDARY_PCIE_CAP_NEXTPTR=0x400/\" $pcie_source"
-#exec /bin/bash -c "sed -i \"s/PF0_SECONDARY_PCIE_CAP_NEXTPTR('H480)/PF0_SECONDARY_PCIE_CAP_NEXTPTR('H400)/\" $pcie_source"
-#exec /bin/bash -c "sed -i \"/PF0_DEVICE_ID(/ a\\\n\\    .PF0_PCIE_CAP_NEXTPTR('HB0),\" $pcie_source"
+set pcie_source $capi_bsp_ip_dir/src/pcie4_uscale_plus_0/synth/pcie4_uscale_plus_0.v
+
+# Adding PF0_PCIE_CAP_NEXTPTR and setting PF0_SECONDARY_PCIE_CAP_NEXTPTR to 0x400
+exec /bin/bash -c "sed -i \"s/PF0_DEVICE_ID=0x0477/PF0_DEVICE_ID=0x0477,PF0_PCIE_CAP_NEXTPTR=0xb0/\" $pcie_source"
+exec /bin/bash -c "sed -i \"s/PF0_SECONDARY_PCIE_CAP_NEXTPTR=0x480/PF0_SECONDARY_PCIE_CAP_NEXTPTR=0x400/\" $pcie_source"
+exec /bin/bash -c "sed -i \"s/PF0_SECONDARY_PCIE_CAP_NEXTPTR('H480)/PF0_SECONDARY_PCIE_CAP_NEXTPTR('H400)/\" $pcie_source"
+exec /bin/bash -c "sed -i \"/PF0_DEVICE_ID(/ a\\\n\\    .PF0_PCIE_CAP_NEXTPTR('HB0),\" $pcie_source"

--- a/U200/xdc/capi_bsp_config.xdc
+++ b/U200/xdc/capi_bsp_config.xdc
@@ -1,0 +1,12 @@
+#S241 configurations
+
+set_property CONFIG_VOLTAGE 1.8 [current_design]
+set_property CONFIG_MODE SPIx4 [current_design]
+set_property BITSTREAM.CONFIG.UNUSEDPIN Pullup [current_design]
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+set_property BITSTREAM.CONFIG.CONFIGRATE 63.8 [current_design]
+#set_property BITSTREAM.CONFIG.NEXT_CONFIG_REBOOT DISABLE [current_design]
+set_property BITSTREAM.CONFIG.EXTMASTERCCLK_EN Disable [current_design]
+set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR YES [current_design]
+set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]
+set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES [current_design]

--- a/U200/xdc/capi_bsp_io.xdc
+++ b/U200/xdc/capi_bsp_io.xdc
@@ -1,0 +1,33 @@
+# Semptian S241 I/O constraints
+
+#Flash
+#Flash uses default dedicated IO
+
+#========================================================
+# PCIE BANK 227/226/225/224 (SLR1 X1Y2)
+#========================================================
+# PCIE hard IP's external dedicated reset pin
+set_property IOSTANDARD LVCMOS12 [get_ports {pcie_rst_n}]
+set_property PACKAGE_PIN AR26 [get_ports {pcie_rst_n}]
+
+# PCIE hard IP's refclk(100M)
+set_property PACKAGE_PIN AM11 [get_ports {pcie_clkp}]
+set_property PACKAGE_PIN AM10 [get_ports {pcie_clkn}]
+
+set_property PACKAGE_PIN AF6  [get_ports {pcie_txn[0]}]
+set_property PACKAGE_PIN AG8  [get_ports {pcie_txn[1]}]
+set_property PACKAGE_PIN AH6  [get_ports {pcie_txn[2]}]
+set_property PACKAGE_PIN AJ8  [get_ports {pcie_txn[3]}]
+set_property PACKAGE_PIN AK6  [get_ports {pcie_txn[4]}]
+set_property PACKAGE_PIN AL8  [get_ports {pcie_txn[5]}]
+set_property PACKAGE_PIN AM6  [get_ports {pcie_txn[6]}]
+set_property PACKAGE_PIN AN8  [get_ports {pcie_txn[7]}]
+
+set_property PACKAGE_PIN AP6  [get_ports {pcie_txn[8]}]
+set_property PACKAGE_PIN AR8  [get_ports {pcie_txn[9]}]
+set_property PACKAGE_PIN AT6  [get_ports {pcie_txn[10]}]
+set_property PACKAGE_PIN AU8  [get_ports {pcie_txn[11]}]
+set_property PACKAGE_PIN AV6  [get_ports {pcie_txn[12]}]
+set_property PACKAGE_PIN BB4  [get_ports {pcie_txn[13]}]
+set_property PACKAGE_PIN BD4  [get_ports {pcie_txn[14]}]
+set_property PACKAGE_PIN BF4  [get_ports {pcie_txn[15]}]

--- a/U200/xdc/capi_bsp_timing.xdc
+++ b/U200/xdc/capi_bsp_timing.xdc
@@ -1,0 +1,20 @@
+############################################################################
+############################################################################
+##
+## Copyright 2018 International Business Machines
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+############################################################################
+############################################################################
+#Semptian S241 timing constraints

--- a/capi_card.mk
+++ b/capi_card.mk
@@ -50,7 +50,7 @@ $(CARD_LOGS):
 
 
 $(CARD_CAPI_BSP_GEN): $(CARD_LOGS)
-	@echo "Creating the PSL for the $(FPGACARD) card."
+	@echo "Creating the PSL for the $(FPGA_CARD) card."
 	@echo "[PREPARE DIRECTORIES.] start "`date +"%T %a %b %d %Y"`
 	@mkdir -p $(CARD_CAPI_BSP_GEN)
 	@echo "[PREPARE DIRECTORIES.] done  "`date +"%T %a %b %d %Y"`

--- a/common/tcl/create_capi_bsp.tcl
+++ b/common/tcl/create_capi_bsp.tcl
@@ -34,6 +34,7 @@ set card_xdc         $::env(CARD_XDC)
 set vivado           $::env(XILINX_VIVADO)
 set top_level        capi_bsp
 set proj_name        capi_board_support
+set fpga_card        $::env(FPGA_CARD)
 
 source $common_tcl/create_ip.tcl
 
@@ -42,6 +43,11 @@ set log_file $::env(CARD_LOGS)/create_capi_bsp.log
 puts "\[CREATE CAPI BSP.....\] start [clock format [clock seconds] -format {%T %a %b %d %Y}]"
 
 create_project $proj_name $proj_dir -part $fpga_part -force >> $log_file
+if {$fpga_card eq "U200"} {
+  set_property board_part xilinx.com:au200:part0:1.0 [current_project]
+#  set_property coreContainer.enable 1 [current_project]
+}
+
 
 #Add source files
 puts "Adding design sources to capi_bsp project"
@@ -114,8 +120,6 @@ if [string match "*2018.3" $vivado] {
     puts "Created $ip_dir/capi_bsp_wrap.xcix"
   } else {
     puts "ERROR: no capi_bsp_wrap.xcix file created!!!"
-}
-
-
+  }
 }
 puts "\[CREATE CAPI BSP.....\] done  [clock format [clock seconds] -format {%T %a %b %d %Y}]"

--- a/common/tcl/create_capi_bsp.tcl
+++ b/common/tcl/create_capi_bsp.tcl
@@ -24,7 +24,6 @@ set psl_version      $::env(PSL_VERSION)
 set capi_bsp_gen_dir $::env(CARD_CAPI_BSP_GEN)
 set capi_bsp_version $::env(CAPI_BSP_VERSION)
 set fpga_part        $::env(FPGA_PART)
-set board_part       $::env(BOARD_PART)
 set proj_dir         $::env(CARD_BUILD)/viv_project
 set card_tcl         $::env(CARD_TCL)
 set common_tcl       $::env(COMMON_TCL)
@@ -43,11 +42,6 @@ set log_file $::env(CARD_LOGS)/create_capi_bsp.log
 puts "\[CREATE CAPI BSP.....\] start [clock format [clock seconds] -format {%T %a %b %d %Y}]"
 
 create_project $proj_name $proj_dir -part $fpga_part -force >> $log_file
-#if {$board_part ne ""} {
-#  puts "Set board_part to $board_part..."
-#  set_property board_part $board_part [current_project]
-# set_property coreContainer.enable 1 [current_project]
-#}
 
 #Add source files
 puts "Adding design sources to capi_bsp project"

--- a/common/tcl/create_ip.tcl
+++ b/common/tcl/create_ip.tcl
@@ -17,12 +17,16 @@
 ##
 ############################################################################
 ############################################################################
+set fpga_card        $::env(FPGA_CARD)
 
 ## Create a new Vivado IP Project
 set log_file $::env(CARD_LOGS)/create_required_ip.log
 puts "\[CREATE REQUIRED IP..\] start [clock format [clock seconds] -format {%T %a %b %d %Y}]"
 exec rm -rf $ip_dir
 create_project managed_ip_project $ip_dir/managed_ip_project -part $fpga_part -ip >> $log_file
+if {$fpga_card eq "U200"} {
+  set_property board_part xilinx.com:au200:part0:1.0 [current_project]
+}
 
 # Project IP Settings
 # General

--- a/psl/create_ip.tcl
+++ b/psl/create_ip.tcl
@@ -19,6 +19,7 @@
 ############################################################################
 
 set fpga_part $::env(FPGA_PART)
+set fpga_card $::env(FPGA_CARD)
 
 set psl_version $::env(PSL_VERSION)
 set ver_major [string range $psl_version 0 [string first "." $psl_version]-1]
@@ -66,6 +67,11 @@ set log_file   $logs_dir/create_ip.log
 
 # Create project
 create_project psl9d $build_dir/viv_project -part $fpga_part -force >> $log_file
+
+if {$fpga_card eq "U200"} {
+  set_property board_part xilinx.com:au200:part0:1.0 [current_project]
+}
+
 
 if { ! [file exists $ip_repo_dir] } {
   puts "Creating PSL9 IP core from encrypted sources"


### PR DESCRIPTION
For 2018.3, it keeps capi2_bsp as xci and not convert it to xcix.