### PR TITLE
re-add clk125MHz for BRAM

### DIFF
--- a/N250SP/src/capi_bsp.vhdl
+++ b/N250SP/src/capi_bsp.vhdl
@@ -969,7 +969,7 @@ pci_exp_rxn(7)    <= pci0_i_rxp_in7;
 pci_exp_rxp(7)    <= pci0_i_rxn_in7;
 
 -- pci_user_reset    <= pcihip0_psl_rst;
--- pci_clock_125MHz  <= psl_clk_div2;
+pci_clock_125MHz  <= psl_clk_div2;
 
 
 pcihip0:      pcie4_uscale_plus_0


### PR DESCRIPTION
JSV reset fixes were ported only on 250SP card but the clk125MHz was removed with comments and this prevents from tests using BRAM instead of DDR to work ok.
Correction is just uncommenting this line so that clk125MHz can be propagated to the BRAM, if any
Signed-off-by: Bruno Mesnet <bruno.mesnet@fr.ibm.com>