### PR TITLE
[FIX] parameters for PLL inside BSP/PSL

### DIFF
--- a/AD9V3/tcl/create_ip.tcl
+++ b/AD9V3/tcl/create_ip.tcl
@@ -119,33 +119,33 @@ if { $action_clock_freq == "225MHZ" } {
 #Create 225MHz specific Clock IP
   puts " CAUTION: Action clock has been set to 225MHZ (default is 250MHZ)"
   create_ip -name clk_wiz -vendor xilinx.com -library ip -module_name uscale_plus_clk_wiz -dir $ip_dir >> $log_file
-
-  set_property -dict [list                                      \
-                    CONFIG.CLKIN1_JITTER_PS {40.0}              \
-                    CONFIG.CLKOUT1_DRIVES {BUFG}                \
-                    CONFIG.CLKOUT1_JITTER {85.736}              \
-                    CONFIG.CLKOUT1_PHASE_ERROR {79.008}         \
-                    CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {250.000} \
-                    CONFIG.CLKOUT2_DRIVES {BUFG}                \
-                    CONFIG.CLKOUT2_JITTER {98.122}              \
-                    CONFIG.CLKOUT2_PHASE_ERROR {79.008}         \
-                    CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {125.000} \
-                    CONFIG.CLKOUT2_USED {true}                  \
-                    CONFIG.CLKOUT3_DRIVES {BUFGCE}              \
-                    CONFIG.CLKOUT3_JITTER {98.122}              \
-                    CONFIG.CLKOUT3_PHASE_ERROR {79.008}         \
-                    CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {125.000} \
-                    CONFIG.CLKOUT3_USED {true}                  \
-                    CONFIG.FEEDBACK_SOURCE {FDBK_AUTO}          \
-                    CONFIG.MMCM_CLKFBOUT_MULT_F {5.000}         \
-                    CONFIG.MMCM_CLKIN1_PERIOD {4.000}           \
-                    CONFIG.MMCM_CLKIN2_PERIOD {10.000}          \
-                    CONFIG.MMCM_CLKOUT0_DIVIDE_F {5.000}        \
-                    CONFIG.MMCM_CLKOUT1_DIVIDE {10}             \
-                    CONFIG.MMCM_CLKOUT2_DIVIDE {10}             \
-                    CONFIG.MMCM_DIVCLK_DIVIDE {1}               \
-                    CONFIG.NUM_OUT_CLKS {3}                     \
-                    CONFIG.PRIM_IN_FREQ {250.000}               \
+  set_property -dict [list                                    \
+                    CONFIG.CLKIN1_JITTER_PS {40.0}          \
+                    CONFIG.CLKOUT1_DRIVES {BUFG}            \
+                    CONFIG.CLKOUT1_JITTER {88.305}          \
+                    CONFIG.CLKOUT1_PHASE_ERROR {80.553}     \
+                    CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {225.000} \
+                    CONFIG.CLKOUT2_DRIVES {BUFG}            \
+                    CONFIG.CLKOUT2_JITTER {99.067}          \
+                    CONFIG.CLKOUT2_PHASE_ERROR {80.553}     \
+                    CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {125} \
+                    CONFIG.CLKOUT2_USED {true}              \
+                    CONFIG.CLKOUT3_DRIVES {BUFGCE}          \
+                    CONFIG.CLKOUT3_JITTER {99.067}          \
+                    CONFIG.CLKOUT3_PHASE_ERROR {80.553}     \
+                    CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {125} \
+                    CONFIG.CLKOUT3_USED {true}              \
+                    CONFIG.FEEDBACK_SOURCE {FDBK_AUTO}      \
+                    CONFIG.MMCM_CLKFBOUT_MULT_F {4.500}     \
+                    CONFIG.MMCM_CLKIN1_PERIOD {4.000}       \
+                    CONFIG.MMCM_CLKIN2_PERIOD {14.999}      \
+                    CONFIG.MMCM_CLKOUT0_DIVIDE_F {5.000}    \
+                    CONFIG.MMCM_CLKOUT1_DIVIDE {9}          \
+                    CONFIG.MMCM_CLKOUT2_DIVIDE {9}          \
+                    CONFIG.MMCM_DIVCLK_DIVIDE {1}           \
+                    CONFIG.NUM_OUT_CLKS {3}                 \
+                    CONFIG.PRIM_IN_FREQ {250}               \
+                    CONFIG.USE_INCLK_SWITCHOVER {false}         \
                    ] [get_ips uscale_plus_clk_wiz] >> $log_file
 } else {
 # create a 250MHz Clock IP


### PR DESCRIPTION
When I was trying to improve the WNS without adding PLL but trying to change the option in make snap_config : "derates the clock by 10%" nothing changed.
Therefore, I decided to investigate and saw that the "IF 225 ELSE 250" was generating the same clocks.
With the fix I propose here I could pass the WNS from -600ps to -300ps, so I conclude it is working.