### PR TITLE
subdevice corrected to 0x0667

### DIFF
--- a/AD9H3/src/capi_bsp.vhdl
+++ b/AD9H3/src/capi_bsp.vhdl
@@ -1071,7 +1071,8 @@ PORT MAP (
 --    cfg_rev_id_pf1 => (others => '0'),       -- in  STD_LOGIC_VECTOR ( 7 downto 0 );
 --    cfg_rev_id_pf2 => (others => '0'),       -- in  STD_LOGIC_VECTOR ( 7 downto 0 );
 --    cfg_rev_id_pf3 => (others => '0'),       -- in  STD_LOGIC_VECTOR ( 7 downto 0 );
-      cfg_subsys_id_pf0 => (X"060f"),      -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
+--    subsys_id_pf0 is used by capi-flash tool to detect the card and assign the proper flash area
+      cfg_subsys_id_pf0 => (X"0667"),      -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
 --    cfg_subsys_id_pf1 => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
 --    cfg_subsys_id_pf2 => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 15 downto 0 );
 --    cfg_subsys_id_pf3 => (others => '0'),      -- in  STD_LOGIC_VECTOR ( 15 downto 0 );


### PR DESCRIPTION
Signed-off-by: Alexandre CASTELLANE <alexandre.castellane@fr.ibm.com>